### PR TITLE
- fix: path completion card name

### DIFF
--- a/components/SecondaryCard.tsx
+++ b/components/SecondaryCard.tsx
@@ -1,19 +1,16 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { CompletedPathCardStyles } from '@styles';
-import { Constants } from '@constants';
 
 interface Props {
-  sehajPathNumber: number;
   pathCompletionDate: string;
+  pathName: string;
 }
 
-export const SecondaryCard = ({ sehajPathNumber, pathCompletionDate }: Props) => {
+export const SecondaryCard = ({ pathCompletionDate, pathName }: Props) => {
   return (
     <View style={CompletedPathCardStyles.container}>
-      <Text style={CompletedPathCardStyles.sehajText}>
-        {Constants.SEHAJ} #{sehajPathNumber}
-      </Text>
+      <Text style={CompletedPathCardStyles.sehajText}>{pathName}</Text>
       <Text style={CompletedPathCardStyles.dateText}>{pathCompletionDate}</Text>
     </View>
   );

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -94,7 +94,7 @@ export const HomeScreen = ({ navigation }: HomeProps) => {
       pathCompleted.map((path: PathData) => (
         <SecondaryCard
           key={path.pathId}
-          sehajPathNumber={path.pathId}
+          pathName={path.pathName}
           pathCompletionDate={path.completionDate}
         />
       )),


### PR DESCRIPTION
Issue
Previously, when a path was completed, the generated completion card displayed a fixed path name. At that time, only the path ID would change, and renaming the path wasn't supported.

Later, support for renaming paths was added, but the completion card logic wasn't updated accordingly. As a result, it continued to show the outdated or default path name.

Fix:
This PR updates the completion path card to reflect the current, user-defined path name, ensuring consistency across the app after the path is renamed.