### PR TITLE
Ios rename navigate

### DIFF
--- a/components/AngsNavigation.tsx
+++ b/components/AngsNavigation.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, TextInput, Pressable } from 'react-native';
+import { View, Text, TouchableOpacity, TextInput, Pressable, StyleSheet } from 'react-native';
 import { BlurView } from '@react-native-community/blur';
 import { AngsNavigationStyle } from '@styles/AngsNavigation';
 import { CrossIcon, LeftArrowIcon, RightArrowIcon } from '@icons';
@@ -97,7 +97,7 @@ export const AngsNavigation = ({
         blurType="light"
         blurAmount={2}
         reducedTransparencyFallbackColor="rgba(0, 0, 0, 0.3)"
-        style={AngsNavigationStyle.blurOverlay}
+        style={StyleSheet.absoluteFillObject}
       />
       <View style={AngsNavigationStyle.overlayContainer}>
         <View style={AngsNavigationStyle.angsNavigationContainer}>

--- a/components/AngsNavigation.tsx
+++ b/components/AngsNavigation.tsx
@@ -92,12 +92,13 @@ export const AngsNavigation = ({
   };
 
   return (
-    <BlurView
-      blurType="light"
-      blurAmount={1}
-      reducedTransparencyFallbackColor="grey"
-      style={AngsNavigationStyle.blurView}
-    >
+    <View style={AngsNavigationStyle.blurView}>
+      <BlurView
+        blurType="light"
+        blurAmount={2}
+        reducedTransparencyFallbackColor="rgba(0, 0, 0, 0.3)"
+        style={AngsNavigationStyle.blurOverlay}
+      />
       <View style={AngsNavigationStyle.overlayContainer}>
         <View style={AngsNavigationStyle.angsNavigationContainer}>
           <Pressable
@@ -167,6 +168,6 @@ export const AngsNavigation = ({
           </TouchableOpacity>
         </View>
       </View>
-    </BlurView>
+    </View>
   );
 };

--- a/components/PathRename.tsx
+++ b/components/PathRename.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, TextInput, Pressable } from 'react-native';
+import { View, Text, TouchableOpacity, TextInput, Pressable, StyleSheet } from 'react-native';
 import { BlurView } from '@react-native-community/blur';
 import { useLocal } from '@hooks';
 import { CrossIcon } from '@icons';
@@ -27,7 +27,7 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
         blurType="light"
         blurAmount={2}
         reducedTransparencyFallbackColor="rgba(0, 0, 0, 0.3)"
-        style={PathRenameStyle.blurOverlay}
+        style={StyleSheet.absoluteFillObject}
       />
       <View style={PathRenameStyle.overlayContainer}>
         <View style={PathRenameStyle.renameContainer}>

--- a/components/PathRename.tsx
+++ b/components/PathRename.tsx
@@ -22,12 +22,13 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
   };
 
   return (
-    <BlurView
-      blurType="light"
-      blurAmount={1}
-      reducedTransparencyFallbackColor="grey"
-      style={PathRenameStyle.blurView}
-    >
+    <View style={PathRenameStyle.blurView}>
+      <BlurView
+        blurType="light"
+        blurAmount={2}
+        reducedTransparencyFallbackColor="rgba(0, 0, 0, 0.3)"
+        style={PathRenameStyle.blurOverlay}
+      />
       <View style={PathRenameStyle.overlayContainer}>
         <View style={PathRenameStyle.renameContainer}>
           <Pressable
@@ -61,6 +62,6 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
           </TouchableOpacity>
         </View>
       </View>
-    </BlurView>
+    </View>
   );
 };

--- a/styles/AngsNavigation.tsx
+++ b/styles/AngsNavigation.tsx
@@ -3,8 +3,14 @@ import font from '@utils/font';
 
 export const AngsNavigationStyle = StyleSheet.create({
   blurView: {
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
     zIndex: 999,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  blurOverlay: {
     position: 'absolute',
     top: 0,
     left: 0,
@@ -30,6 +36,14 @@ export const AngsNavigationStyle = StyleSheet.create({
     alignItems: 'center',
     gap: 15,
     borderRadius: 15,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
   },
   angsNavigationText: {
     fontSize: 18,

--- a/styles/AngsNavigation.tsx
+++ b/styles/AngsNavigation.tsx
@@ -10,13 +10,7 @@ export const AngsNavigationStyle = StyleSheet.create({
     right: 0,
     bottom: 0,
   },
-  blurOverlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
+
   overlayContainer: {
     padding: 15,
     width: '100%',
@@ -25,7 +19,6 @@ export const AngsNavigationStyle = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-
   angsNavigationContainer: {
     backgroundColor: '#EBF0F8',
     position: 'relative',

--- a/styles/PathRenameStyle.tsx
+++ b/styles/PathRenameStyle.tsx
@@ -11,13 +11,6 @@ export const PathRenameStyle = StyleSheet.create({
     bottom: 0,
     elevation: 1,
   },
-  blurOverlay: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-  },
   overlayContainer: {
     padding: 15,
     width: '100%',

--- a/styles/PathRenameStyle.tsx
+++ b/styles/PathRenameStyle.tsx
@@ -3,13 +3,30 @@ import { StyleSheet } from 'react-native';
 
 export const PathRenameStyle = StyleSheet.create({
   blurView: {
-    backgroundColor: 'rgba(255, 255, 255, 0.1)',
-    zIndex: 999,
+    zIndex: 9999,
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
     bottom: 0,
+    elevation: 1,
+  },
+  blurOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  iosOverlay: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    zIndex: 9999,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    elevation: 10,
   },
   overlayContainer: {
     padding: 15,
@@ -29,6 +46,14 @@ export const PathRenameStyle = StyleSheet.create({
     alignItems: 'center',
     gap: 15,
     borderRadius: 15,
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 3.84,
+    elevation: 5,
   },
   renameText: {
     fontSize: 18,

--- a/styles/PathRenameStyle.tsx
+++ b/styles/PathRenameStyle.tsx
@@ -18,16 +18,6 @@ export const PathRenameStyle = StyleSheet.create({
     right: 0,
     bottom: 0,
   },
-  iosOverlay: {
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    zIndex: 9999,
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    elevation: 10,
-  },
   overlayContainer: {
     padding: 15,
     width: '100%',


### PR DESCRIPTION
# Fixed the UI compoents for the  Path rename and the angs navigation compoent in path screen 
## Before:

-   ## Android

<img width="346" height="714" alt="Screenshot 2025-08-19 at 1 43 40 AM" src="https://github.com/user-attachments/assets/e04cf15c-bad1-4704-aa39-ddb3516a0006" />
<img width="347" height="735" alt="Screenshot 2025-08-19 at 1 43 57 AM" src="https://github.com/user-attachments/assets/eabed64d-48ee-48ae-ae38-c7504f10db87" />

- ## IOS
<img width="263" height="529" alt="Screenshot 2025-08-19 at 1 43 11 AM" src="https://github.com/user-attachments/assets/cbea0fb7-6d35-4479-9e4e-16f3d9ab24cb" /><img width="264" height="525" alt="Screenshot 2025-08-19 at 1 43 24 AM" src="https://github.com/user-attachments/assets/e66aed39-8350-453e-8e8a-e76ead4cb10d" />


## After
-  ## Android
<img width="350" height="710" alt="Screenshot 2025-08-19 at 1 50 33 AM" src="https://github.com/user-attachments/assets/b41b4af0-d062-41b1-a3d2-1a9e6ba39d5b" />
<img width="346" height="744" alt="Screenshot 2025-08-19 at 1 44 54 AM" src="https://github.com/user-attachments/assets/a213bfdc-645e-44ba-ac14-346f6f2e9f4d" />

- ## IOS
<img width="262" height="552" alt="Screenshot 2025-08-19 at 1 42 23 AM" src="https://github.com/user-attachments/assets/75a48924-6a28-410b-8eb0-576d1e734d19" />
<img width="258" height="549" alt="Screenshot 2025-08-19 at 1 42 42 AM" src="https://github.com/user-attachments/assets/b1724e3d-5504-4467-a8d5-8d6496f19482" />


