### PR TITLE
- fixed the streak calculation with checking base condition

### DIFF
--- a/components/Calender.tsx
+++ b/components/Calender.tsx
@@ -22,6 +22,12 @@ export const Calender = ({ pathId, streak, onStreakUpdate }: Props) => {
     if (!dates || dates.length === 0) {
       return 0;
     }
+    const today = dayjs();
+    const todayString = today.format('D-MMMM-YYYY');
+
+    if (!dates.includes(todayString)) {
+      return 0;
+    }
 
     const sortedDates = dates
       .map((dateStr) => dayjs(dateStr, 'D-MMMM-YYYY'))


### PR DESCRIPTION
- This fixed the the streak calculation as it was showing a streak count even when the user hadn't completed today's path yet. 
- This was misleading as it would display "1 day streak" before the user had actually done any reading for the current day.