### PR TITLE
- fixed: added input validatioin to the path rename functionaly

### DIFF
--- a/components/PathRename.tsx
+++ b/components/PathRename.tsx
@@ -14,8 +14,24 @@ interface Props {
 export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
   const { renamePath } = useLocal();
   const [newName, setNewName] = useState<string>('');
+  const [isValid, setIsValid] = useState<boolean>(true);
+
+  const handleNameChange = (text: string) => {
+    setNewName(text);
+    if (text.trim() === '') {
+      setIsValid(false);
+    } else {
+      setIsValid(true);
+    }
+  };
+
+  const isUpdateButtonDisabled = !isValid || newName.trim() === '';
 
   const handleRename = () => {
+    if (isUpdateButtonDisabled) {
+      return;
+    }
+
     renamePath(pathId, newName);
     setPathRename(false);
     setPathName(newName);
@@ -47,18 +63,35 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
             placeholderTextColor={'grey'}
             autoFocus={false}
             value={newName}
-            onChangeText={setNewName}
+            onChangeText={handleNameChange}
             accessibilityLabel="Path name input field"
             accessibilityHint="Enter a new name for your Sehaj Path"
           />
+          {!isValid && newName !== '' && (
+            <Text style={PathRenameStyle.warningText}>
+              Name cannot be empty
+            </Text>
+          )}
           <TouchableOpacity
-            style={PathRenameStyle.updateButton}
+            style={[
+              PathRenameStyle.updateButton,
+              isUpdateButtonDisabled && PathRenameStyle.disabledButton,
+            ]}
             onPress={handleRename}
+            disabled={isUpdateButtonDisabled}
             accessibilityLabel="Update path name"
             accessibilityRole="button"
             accessibilityHint="Tap to save the new path name"
+            accessibilityState={{ disabled: isUpdateButtonDisabled }}
           >
-            <Text style={PathRenameStyle.buttonText}>Update</Text>
+            <Text
+              style={[
+                PathRenameStyle.buttonText,
+                isUpdateButtonDisabled && PathRenameStyle.disabledButtonText,
+              ]}
+            >
+              Update
+            </Text>
           </TouchableOpacity>
         </View>
       </View>

--- a/components/PathRename.tsx
+++ b/components/PathRename.tsx
@@ -18,11 +18,7 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
 
   const handleNameChange = (text: string) => {
     setNewName(text);
-    if (text.trim() === '') {
-      setIsValid(false);
-    } else {
-      setIsValid(true);
-    }
+    setIsValid(text.trim() !== '');
   };
 
   const isUpdateButtonDisabled = !isValid || newName.trim() === '';
@@ -31,7 +27,6 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
     if (isUpdateButtonDisabled) {
       return;
     }
-
     renamePath(pathId, newName);
     setPathRename(false);
     setPathName(newName);
@@ -68,9 +63,7 @@ export const PathRename = ({ pathId, setPathRename, setPathName }: Props) => {
             accessibilityHint="Enter a new name for your Sehaj Path"
           />
           {!isValid && newName !== '' && (
-            <Text style={PathRenameStyle.warningText}>
-              Name cannot be empty
-            </Text>
+            <Text style={PathRenameStyle.warningText}>Name cannot be empty</Text>
           )}
           <TouchableOpacity
             style={[

--- a/styles/PathRenameStyle.tsx
+++ b/styles/PathRenameStyle.tsx
@@ -72,4 +72,18 @@ export const PathRenameStyle = StyleSheet.create({
     right: 10,
     zIndex: 999,
   },
+  warningText: {
+    color: '#FF6B6B',
+    fontSize: 14,
+    fontFamily: font.Baloo_Paaji_2_Medium,
+    textAlign: 'center',
+    marginTop: -5,
+  },
+  disabledButton: {
+    backgroundColor: '#CCCCCC',
+    opacity: 0.6,
+  },
+  disabledButtonText: {
+    color: '#888888',
+  },
 });


### PR DESCRIPTION
Problem
- The Path Rename dialog allowed users to save empty or whitespace-only names, which could lead to confusing path names in the app.
Solution
- Added real-time input validation for preventing the name to be empty