### PR TITLE
- fixed the pressable default styling on the ios

### DIFF
--- a/components/SimpleTextForPath.tsx
+++ b/components/SimpleTextForPath.tsx
@@ -91,6 +91,7 @@ export const SimpleTextForPath = ({
       accessibilityHint="Tap to select, long press to save this line"
     >
       <Text
+        suppressHighlighting={true}
         style={{
           ...SimpleTextForPathStyles.text,
           fontSize,


### PR DESCRIPTION
Problem 
- On iOS, tapping a Text inside SimpleTextForPath showed the default gray highlight background, which was not desired.

Solution
- Added the `suppressHighlighting` prop for overriding the IOS UI native kit behaviour