### PR TITLE
Ang navigation fix

### DIFF
--- a/components/PathReader.tsx
+++ b/components/PathReader.tsx
@@ -41,7 +41,7 @@ interface PathReaderProps {
   isVishraam: boolean;
   vishraamsSource: string;
   vishraamsStyle: string;
-  onSaveCommit?: (angNumber: number, verseId: number) => void;
+  onSaveCommit?: (angNumber: number, verseId: number, clearAngNavigation?: boolean) => void;
   setCenterVerseId?: (verseId: number) => void;
   scrollToVerseId?: number;
   scrolledToSavedPath: React.MutableRefObject<boolean>;
@@ -182,7 +182,7 @@ const PathReaderComponent = ({
         setIsSaved
       );
       if (saved && onSaveCommit) {
-        onSaveCommit(pathContent?.source?.pageNo ?? 0, verseId);
+        onSaveCommit(pathContent?.source?.pageNo ?? 0, verseId, true);
       }
     },
     [

--- a/hooks/useNavigation.ts
+++ b/hooks/useNavigation.ts
@@ -7,6 +7,7 @@ export interface UseNavigationParams {
   isNavigating: boolean;
   setIsNavigating: (value: boolean) => void;
   setIsSaving: (value: boolean) => void;
+  setIsAngNavigation: (value: boolean) => void;
   scrollOffset: React.MutableRefObject<number>;
   scrollRef: React.MutableRefObject<ScrollView | null>;
   setPathAng: (value: number) => void;
@@ -18,6 +19,7 @@ export const useNavigation = ({
   isNavigating,
   setIsNavigating,
   setIsSaving,
+  setIsAngNavigation,
   scrollOffset,
   scrollRef,
   setPathAng,
@@ -34,6 +36,7 @@ export const useNavigation = ({
       }
 
       setIsNavigating(true);
+      setIsAngNavigation(false);
       setIsSaving(false);
       scrollOffset.current = 0;
       scrollRef.current?.scrollTo({
@@ -70,6 +73,7 @@ export const useNavigation = ({
       checkNetwork,
       setIsNavigating,
       setIsSaving,
+      setIsAngNavigation,
       scrollOffset,
       scrollRef,
       fetchFromBaniDB,
@@ -87,6 +91,7 @@ export const useNavigation = ({
       }
 
       setIsNavigating(true);
+      setIsAngNavigation(false);
       setIsSaving(false);
       scrollOffset.current = 0;
       scrollRef.current?.scrollTo({
@@ -121,6 +126,7 @@ export const useNavigation = ({
       isNavigating,
       setIsNavigating,
       setIsSaving,
+      setIsAngNavigation,
       scrollOffset,
       scrollRef,
       setPathAng,

--- a/hooks/useNavigation.ts
+++ b/hooks/useNavigation.ts
@@ -7,7 +7,6 @@ export interface UseNavigationParams {
   isNavigating: boolean;
   setIsNavigating: (value: boolean) => void;
   setIsSaving: (value: boolean) => void;
-  setIsAngNavigation: (value: boolean) => void;
   scrollOffset: React.MutableRefObject<number>;
   scrollRef: React.MutableRefObject<ScrollView | null>;
   setPathAng: (value: number) => void;
@@ -19,7 +18,6 @@ export const useNavigation = ({
   isNavigating,
   setIsNavigating,
   setIsSaving,
-  setIsAngNavigation,
   scrollOffset,
   scrollRef,
   setPathAng,
@@ -36,7 +34,6 @@ export const useNavigation = ({
       }
 
       setIsNavigating(true);
-      setIsAngNavigation(false);
       setIsSaving(false);
       scrollOffset.current = 0;
       scrollRef.current?.scrollTo({
@@ -73,7 +70,6 @@ export const useNavigation = ({
       checkNetwork,
       setIsNavigating,
       setIsSaving,
-      setIsAngNavigation,
       scrollOffset,
       scrollRef,
       fetchFromBaniDB,
@@ -91,7 +87,6 @@ export const useNavigation = ({
       }
 
       setIsNavigating(true);
-      setIsAngNavigation(false);
       setIsSaving(false);
       scrollOffset.current = 0;
       scrollRef.current?.scrollTo({
@@ -126,7 +121,6 @@ export const useNavigation = ({
       isNavigating,
       setIsNavigating,
       setIsSaving,
-      setIsAngNavigation,
       scrollOffset,
       scrollRef,
       setPathAng,

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -144,6 +144,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     isNavigating,
     setIsNavigating,
     setIsSaving,
+    setIsAngNavigation,
     scrollOffset,
     scrollRef,
     setPathAng,

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -144,7 +144,6 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     isNavigating,
     setIsNavigating,
     setIsSaving,
-    setIsAngNavigation,
     scrollOffset,
     scrollRef,
     setPathAng,
@@ -187,23 +186,29 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     [clearPathCompletionAndSavedVerse, resetCompletionViewState, route.params.pathId]
   );
 
-  const commitSavedPathState = useCallback((angNumber: number, verseId: number) => {
-    if (!matchedPath.current) {
-      return;
-    }
-    matchedPath.current.saveData = { angNumber, verseId };
-    matchedPath.current.completionDate =
-      angNumber === PATH_DATA.LAST_ANG_NUMBER && verseId === PATH_DATA.LAST_VERSE_ID
-        ? matchedPath.current.completionDate || new Date().toISOString()
-        : '';
-    setSavedAngNumber(angNumber);
-    setSavedPathVerseId(verseId);
-    completionUndoPendingRef.current =
-      angNumber === PATH_DATA.LAST_ANG_NUMBER && verseId === PATH_DATA.LAST_VERSE_ID;
-    if (completionUndoPendingRef.current) {
-      completionUndoStartScrollYRef.current = scrollOffset.current;
-    }
-  }, []);
+  const commitSavedPathState = useCallback(
+    (angNumber: number, verseId: number, clearAngNavigation = false) => {
+      if (!matchedPath.current) {
+        return;
+      }
+      matchedPath.current.saveData = { angNumber, verseId };
+      matchedPath.current.completionDate =
+        angNumber === PATH_DATA.LAST_ANG_NUMBER && verseId === PATH_DATA.LAST_VERSE_ID
+          ? matchedPath.current.completionDate || new Date().toISOString()
+          : '';
+      setSavedAngNumber(angNumber);
+      setSavedPathVerseId(verseId);
+      completionUndoPendingRef.current =
+        angNumber === PATH_DATA.LAST_ANG_NUMBER && verseId === PATH_DATA.LAST_VERSE_ID;
+      if (completionUndoPendingRef.current) {
+        completionUndoStartScrollYRef.current = scrollOffset.current;
+      }
+      if (clearAngNavigation) {
+        setIsAngNavigation(false);
+      }
+    },
+    [scrollOffset, setIsAngNavigation]
+  );
 
   const debouncedScrollSave = useCallback(() => {
     if (debounceTimer.current) {


### PR DESCRIPTION
# Problem
-  When a user jumped to a different ang using the ang navigation flow, then saved a panktee over there
- Then the user then moved again with the top arrow buttons,and then tried to exit the path without saving the panktee then it was still again prompting to save but it should not.

# Solution
 - Clear that ang-navigation state only after an explicit line save.