### PR TITLE
- Fixed the path drawer navigton to back to path issue

### DIFF
--- a/constants/constant.ts
+++ b/constants/constant.ts
@@ -51,4 +51,5 @@ export const Constants: Constant = {
   STREAKS: 'Streaks',
   GO_TO_ANG: 'Go To Ang',
   SAVE: 'Save',
+  BACK_TO_PATH: 'Back to path',
 };

--- a/hooks/useDrawerNavigation.ts
+++ b/hooks/useDrawerNavigation.ts
@@ -9,40 +9,30 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 export const useDrawerNavigation = () => {
   const navigation = useNavigation<NavigationProp>();
 
-  const handleDrawerNavigate = useCallback((route: string, pathId?: number) => {
-    switch (route) {
-      case 'Home':
-        navigation.navigate(Routes.Home);
-        break;
-      case 'Setting':
-        navigation.navigate(Routes.Setting);
-        break;
-      case 'Progress':
-        // Navigate to Continue screen with the current pathId to show progress
-        if (pathId) {
-          navigation.push(Routes.Continue, { pathId, initialTab: 'progress' });
+  const handleDrawerNavigate = useCallback(
+    (route: string, pathId?: number) => {
+      const navigateToContinue = (initialTab: 'progress' | 'streak') => {
+        if (!pathId) {
+          return;
         }
-        break;
-      case 'Streaks':
-        // Navigate to Continue screen with the current pathId to show streak tab
-        if (pathId) {
-          navigation.push(Routes.Continue, { pathId, initialTab: 'streak' });
-        }
-        break;
-      case 'GoToAng':
-        // Handling this using callback
-        break;
-      case 'Save':
-        // Handling this using callback
-        break;
-      case 'Login':
-        // Add navigation when Login screen is implemented
-        // navigation.navigate(Routes.Login);
-        break;
-      default:
-        break;
-    }
-  }, [navigation]);
+
+        navigation.push(Routes.Continue, {
+          pathId,
+          initialTab,
+        });
+      };
+
+      const routeHandlers: Record<string, () => void> = {
+        Home: () => navigation.navigate(Routes.Home),
+        Setting: () => navigation.navigate(Routes.Setting),
+        Progress: () => navigateToContinue('progress'),
+        Streaks: () => navigateToContinue('streak'),
+      };
+
+      routeHandlers[route]?.();
+    },
+    [navigation]
+  );
 
   return { handleDrawerNavigate };
 };

--- a/screens/Continue.tsx
+++ b/screens/Continue.tsx
@@ -4,7 +4,7 @@ import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { View, ScrollView, ImageBackground, Text, Pressable, Image } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useFocusEffect } from '@react-navigation/native';
+import { useFocusEffect, useNavigationState } from '@react-navigation/native';
 import {
   NavContent,
   SecondaryButton,
@@ -54,6 +54,8 @@ export const Continue = ({ route, navigation }: ContinueProps) => {
   const streak = useRef<number>(0);
   const { fetchFromLocal } = useLocal();
   const { checkNetwork } = useInternet();
+  const previousRoute = useNavigationState((state) => state.routes[state.index - 1]?.name);
+  const isFromPath = previousRoute === Routes.Path;
 
   const handleStreakUpdate = useCallback((newStreakValue: number) => {
     setUiState((prev) => ({ ...prev, streakValue: newStreakValue }));
@@ -145,8 +147,13 @@ export const Continue = ({ route, navigation }: ContinueProps) => {
   }, []);
 
   const handleBackPress = useCallback(() => {
+    if (isFromPath) {
+      navigation.goBack();
+      return;
+    }
+
     navigation.replace(Routes.Home);
-  }, [navigation]);
+  }, [navigation, isFromPath]);
 
   const progressText = useMemo(
     () => [
@@ -192,12 +199,14 @@ export const Continue = ({ route, navigation }: ContinueProps) => {
             <Pressable
               style={ContinueScreenStyles.navContainer}
               onPress={handleBackPress}
-              accessibilityLabel="Back to home"
+              accessibilityLabel={isFromPath ? Constants.BACK_TO_PATH : 'Back to home'}
               accessibilityRole="button"
-              accessibilityHint="Tap to go back to home screen"
+              accessibilityHint={
+                isFromPath ? 'Tap to go back to the path screen' : 'Tap to go back to home screen'
+              }
             >
               <NavContent navIcon={<LeftArrowIcon />} onPress={handleBackPress} />
-              <NavContent text={Constants.SEE_ALL_PATH} />
+              <NavContent text={isFromPath ? Constants.BACK_TO_PATH : Constants.SEE_ALL_PATH} />
             </Pressable>
             <View style={ContinueScreenStyles.tabsContainer}>
               <Pressable


### PR DESCRIPTION
# Problem
- When user opens drawer from any path then select the progress or streak then the in that screen i.e. the continue screen the header show the `Show All Path` insted of `Back to path`

# Solution
- Updated Continue to derive its back label from navigation history instead of relying on a passed
    flag.
- Added useNavigationState logic in Continue to detect when the previous route is Path.
- Also improved the `useDrawerNavigation` hook