### PR TITLE
- Fixed the scroll issue with the centerverseid while changing the font

### DIFF
--- a/components/ParagraphTextForPath.tsx
+++ b/components/ParagraphTextForPath.tsx
@@ -34,6 +34,7 @@ const ParagraphTextForPathComponent = ({
   vishraams,
   vishraamsSource,
   originalVerse,
+  onLayout,
 }: PathTextProps) => {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressLock = useRef(false);
@@ -102,6 +103,7 @@ const ParagraphTextForPathComponent = ({
       disabled={isSaved || found}
       suppressHighlighting={true}
       style={[textStyle, containerStyle]}
+      onLayout={onLayout}
     >
       {isVishraam ? (
         <VishraamsText
@@ -112,7 +114,7 @@ const ParagraphTextForPathComponent = ({
         />
       ) : (
         gurbaniLine
-      )}{" "}
+      )}{' '}
       {isSelected && (
         <Text>
           <SaveIcon
@@ -127,4 +129,7 @@ const ParagraphTextForPathComponent = ({
   );
 };
 
-export const ParagraphTextForPath = React.memo(ParagraphTextForPathComponent, pathTextPropsAreEqual);
+export const ParagraphTextForPath = React.memo(
+  ParagraphTextForPathComponent,
+  pathTextPropsAreEqual
+);

--- a/components/PathReader.tsx
+++ b/components/PathReader.tsx
@@ -121,13 +121,12 @@ const PathReaderComponent = ({
     (e: any) => {
       const scrollY = e.nativeEvent.contentOffset.y;
       scrollOffset.current = scrollY;
-      findCenterVerseId(scrollY);
 
       if (!isAngNavigation) {
         debouncedScrollSave();
       }
     },
-    [isAngNavigation, debouncedScrollSave, scrollOffset, findCenterVerseId]
+    [isAngNavigation, debouncedScrollSave, scrollOffset]
   );
 
   const gestureConfig = useMemo(
@@ -344,9 +343,11 @@ const PathReaderComponent = ({
           setFound(false);
         }}
         onScrollEndDrag={() => {
+          findCenterVerseId(scrollOffset.current);
           onScrollEndDrag?.(scrollOffset.current);
         }}
         onMomentumScrollEnd={() => {
+          findCenterVerseId(scrollOffset.current);
           onScrollEndDrag?.(scrollOffset.current);
         }}
         scrollEventThrottle={16}

--- a/components/PathReader.tsx
+++ b/components/PathReader.tsx
@@ -1,9 +1,10 @@
-import React, { useCallback, useMemo, useRef, useEffect } from 'react';
+import React, { useCallback, useMemo, useEffect, useLayoutEffect } from 'react';
 import GestureRecognizer from 'react-native-swipe-gestures';
-import { ScrollView, Text, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { ParagraphTextForPath, SimpleTextForPath } from '@components';
 import { PathReaderStyles } from '@styles';
 import { PathNextAng } from './PathNextAng';
+import { usePathReaderCentering } from './usePathReaderCentering';
 import { trackEvent } from '@utils/analytics';
 import { PATH_DATA } from '@constants';
 import type { Verse, PathContent } from '@hooks';
@@ -49,6 +50,7 @@ interface PathReaderProps {
   ) => void;
   setCenterVerseId?: (verseId: number) => void;
   scrollToVerseId?: number;
+  scrollToVerseRequestKey?: number;
   scrolledToSavedPath: React.MutableRefObject<boolean>;
   onScrollEndDrag?: (scrollY: number) => void;
 }
@@ -83,13 +85,24 @@ const PathReaderComponent = ({
   onSaveCommit,
   setCenterVerseId,
   scrollToVerseId,
+  scrollToVerseRequestKey,
   scrolledToSavedPath,
   onScrollEndDrag,
 }: PathReaderProps) => {
-  const viewportHeight = useRef<number>(0);
-  const versePositions = useRef<Map<number, { y: number; height: number }>>(new Map());
-  const hasScrolledToVerse = useRef<boolean>(false);
-  const scrollEndTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const {
+    clearMeasuredVerses,
+    createLayoutHandler,
+    createParagraphVerseLayoutHandler,
+    createShabadLayoutHandler,
+    findCenterVerseId,
+    handleViewportLayout,
+    requestRecenter,
+  } = usePathReaderCentering({
+    scrollRef,
+    scrollOffset,
+    setCenterVerseId,
+    scrollToVerseId,
+  });
 
   const handleAngChange = useCallback(() => {
     trackEvent('AngsByBottomNav', 'click', 'next ang from bottom nav');
@@ -104,52 +117,11 @@ const PathReaderComponent = ({
     handleLeftArrow(pathContent?.source?.pageNo);
   }, [handleLeftArrow, pathContent?.source?.pageNo]);
 
-  const findCenterVerseId = useCallback(
-    (scrollY: number) => {
-      if (!setCenterVerseId) {
-        return;
-      }
-
-      // Wait for verses to be measured
-      if (versePositions.current.size === 0) {
-        return;
-      }
-
-      const centerY = scrollY + viewportHeight.current / 2;
-      let closestVerseId: number | null = null;
-      let minDistance = Infinity;
-
-      versePositions.current.forEach((position, verseId) => {
-        const verseCenter = position.y + position.height / 2;
-        const distance = Math.abs(verseCenter - centerY);
-
-        if (distance < minDistance) {
-          minDistance = distance;
-          closestVerseId = verseId;
-        }
-      });
-
-      if (closestVerseId !== null) {
-        setCenterVerseId(closestVerseId);
-      }
-    },
-    [setCenterVerseId]
-  );
-
   const handleScroll = useCallback(
     (e: any) => {
       const scrollY = e.nativeEvent.contentOffset.y;
       scrollOffset.current = scrollY;
-
-      // Clear existing timer
-      if (scrollEndTimer.current) {
-        clearTimeout(scrollEndTimer.current);
-      }
-
-      // Set new timer to detect when scrolling stops
-      scrollEndTimer.current = setTimeout(() => {
-        findCenterVerseId(scrollY);
-      }, 150); // Wait 150ms after scrolling stops
+      findCenterVerseId(scrollY);
 
       if (!isAngNavigation) {
         debouncedScrollSave();
@@ -200,58 +172,20 @@ const PathReaderComponent = ({
     ]
   );
 
-  const createLayoutHandler = useCallback(
-    (verseId: number) => (event: any) => {
-      const { y, height } = event.nativeEvent.layout;
-      versePositions.current.set(verseId, { y, height });
-
-      // If we're waiting to scroll to this verse, do it now
-      if (
-        scrollToVerseId === verseId &&
-        !hasScrolledToVerse.current &&
-        scrollRef.current &&
-        viewportHeight.current > 0
-      ) {
-        const verseY = y;
-        const verseCenterY = verseY + height / 2;
-        const screenCenterY = viewportHeight.current / 2;
-        const targetScroll = Math.max(0, verseCenterY - screenCenterY);
-
-        // Scroll immediately without delay to prevent verse from jumping
-        if (scrollRef.current) {
-          scrollRef.current.scrollTo({
-            y: targetScroll,
-            animated: false,
-          });
-          scrollOffset.current = targetScroll;
-          hasScrolledToVerse.current = true;
-        }
-      }
-    },
-    [scrollToVerseId, scrollRef, scrollOffset]
-  );
-
   // Clear verse positions when page changes
-  useEffect(() => {
-    versePositions.current.clear();
-    hasScrolledToVerse.current = false;
-    if (setCenterVerseId) {
-      setCenterVerseId(0);
-    }
-  }, [pathContent?.source?.pageNo, setCenterVerseId]);
+  useLayoutEffect(() => {
+    clearMeasuredVerses(true);
+  }, [clearMeasuredVerses, pathContent?.source?.pageNo]);
 
   // Clear verse positions when font size or paragraph mode changes
-  useEffect(() => {
-    versePositions.current.clear();
-    hasScrolledToVerse.current = false;
-  }, [fontSize, isParagraphMode]);
+  useLayoutEffect(() => {
+    clearMeasuredVerses();
+  }, [clearMeasuredVerses, fontSize, isParagraphMode]);
 
   // Reset scroll flag when scrollToVerseId changes
   useEffect(() => {
-    if (scrollToVerseId) {
-      hasScrolledToVerse.current = false;
-    }
-  }, [scrollToVerseId]);
+    requestRecenter(scrollToVerseId);
+  }, [requestRecenter, scrollToVerseId, scrollToVerseRequestKey]);
 
   const shabadsWithIndices = useMemo(() => {
     if (!pathContent?.page) {
@@ -282,11 +216,14 @@ const PathReaderComponent = ({
       return (
         <View>
           {shabadsWithIndices.map((shabad, shabadIndex) => (
-            <Text
+            <View
               key={shabadIndex}
+              onLayout={createShabadLayoutHandler(shabadIndex)}
               style={{
                 marginBottom: 14,
-                lineHeight: fontSize * 1.6,
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                alignItems: 'flex-start',
               }}
             >
               {shabad.verses.map((verse: Verse, verseIndex: number) => {
@@ -302,6 +239,7 @@ const PathReaderComponent = ({
                     gurbaniLine={gurbaniLine}
                     onSelection={createSelectionHandler(verseIndex, verse.verseId)}
                     onSave={createSaveHandler(verse.verseId)}
+                    onLayout={createParagraphVerseLayoutHandler(verse.verseId, shabadIndex)}
                     isSaving={isSaving}
                     pressIndex={pressIndex}
                     index={globalIndex}
@@ -323,7 +261,7 @@ const PathReaderComponent = ({
                   />
                 );
               })}
-            </Text>
+            </View>
           ))}
         </View>
       );
@@ -370,6 +308,8 @@ const PathReaderComponent = ({
     createSelectionHandler,
     createSaveHandler,
     createLayoutHandler,
+    createParagraphVerseLayoutHandler,
+    createShabadLayoutHandler,
     setIsSaving,
     setIsSaved,
     setPressIndex,
@@ -414,9 +354,7 @@ const PathReaderComponent = ({
         onStartShouldSetResponder={() => false}
         onMoveShouldSetResponder={() => false}
         removeClippedSubviews={true}
-        onLayout={(e) => {
-          viewportHeight.current = e.nativeEvent.layout.height;
-        }}
+        onLayout={handleViewportLayout}
       >
         {pageContent}
         {pathContent?.source?.pageNo < PATH_DATA.LAST_ANG_NUMBER && !isNavigating && (

--- a/components/usePathReaderCentering.ts
+++ b/components/usePathReaderCentering.ts
@@ -1,0 +1,189 @@
+import { useCallback, useRef } from 'react';
+import type { RefObject } from 'react';
+import type { LayoutChangeEvent, ScrollView } from 'react-native';
+
+type VersePosition = {
+  y: number;
+  height: number;
+};
+
+type ParagraphVerseLayout = {
+  shabadIndex: number;
+  localY: number;
+  height: number;
+};
+
+type UsePathReaderCenteringArgs = {
+  scrollRef: RefObject<ScrollView | null>;
+  scrollOffset: RefObject<number>;
+  setCenterVerseId?: (verseId: number) => void;
+  scrollToVerseId?: number;
+};
+
+export const usePathReaderCentering = ({
+  scrollRef,
+  scrollOffset,
+  setCenterVerseId,
+  scrollToVerseId,
+}: UsePathReaderCenteringArgs) => {
+  const viewportHeight = useRef<number>(0);
+  const versePositions = useRef<Map<number, VersePosition>>(new Map());
+  const paragraphOffsets = useRef<Map<number, number>>(new Map());
+  const paragraphVerseLayouts = useRef<Map<number, ParagraphVerseLayout>>(new Map());
+  const hasScrolledToVerse = useRef<boolean>(false);
+
+  const recenterVerse = useCallback(
+    (verseId: number) => {
+      const position = versePositions.current.get(verseId);
+      if (!position || !scrollRef.current || viewportHeight.current <= 0) {
+        return;
+      }
+
+      const verseCenterY = position.y + position.height / 2;
+      const screenCenterY = viewportHeight.current / 2;
+      const targetScroll = Math.max(0, verseCenterY - screenCenterY);
+
+      scrollRef.current.scrollTo({
+        y: targetScroll,
+        animated: false,
+      });
+      scrollOffset.current = targetScroll;
+      setCenterVerseId?.(verseId);
+      hasScrolledToVerse.current = true;
+    },
+    [scrollRef, scrollOffset, setCenterVerseId]
+  );
+
+  const findCenterVerseId = useCallback(
+    (scrollY: number) => {
+      if (!setCenterVerseId || versePositions.current.size === 0) {
+        return;
+      }
+
+      const centerY = scrollY + viewportHeight.current / 2;
+      let closestVerseId: number | null = null;
+      let minDistance = Infinity;
+
+      versePositions.current.forEach((position, verseId) => {
+        const verseCenter = position.y + position.height / 2;
+        const distance = Math.abs(verseCenter - centerY);
+
+        if (distance < minDistance) {
+          minDistance = distance;
+          closestVerseId = verseId;
+        }
+      });
+
+      if (closestVerseId !== null) {
+        setCenterVerseId(closestVerseId);
+      }
+    },
+    [setCenterVerseId]
+  );
+
+  const syncParagraphVersePosition = useCallback(
+    (verseId: number) => {
+      const localLayout = paragraphVerseLayouts.current.get(verseId);
+      if (!localLayout) {
+        return;
+      }
+
+      const shabadOffset = paragraphOffsets.current.get(localLayout.shabadIndex);
+      if (shabadOffset === undefined) {
+        return;
+      }
+
+      const resolvedY = shabadOffset + localLayout.localY;
+      versePositions.current.set(verseId, { y: resolvedY, height: localLayout.height });
+
+      if (scrollToVerseId === verseId && !hasScrolledToVerse.current) {
+        recenterVerse(verseId);
+      }
+    },
+    [recenterVerse, scrollToVerseId]
+  );
+
+  const createLayoutHandler = useCallback(
+    (verseId: number) => (event: LayoutChangeEvent) => {
+      const { y, height } = event.nativeEvent.layout;
+      versePositions.current.set(verseId, { y, height });
+
+      if (scrollToVerseId === verseId && !hasScrolledToVerse.current) {
+        recenterVerse(verseId);
+      }
+    },
+    [recenterVerse, scrollToVerseId]
+  );
+
+  const createParagraphVerseLayoutHandler = useCallback(
+    (verseId: number, shabadIndex: number) => (event: LayoutChangeEvent) => {
+      const { y, height } = event.nativeEvent.layout;
+      paragraphVerseLayouts.current.set(verseId, {
+        shabadIndex,
+        localY: y,
+        height,
+      });
+
+      syncParagraphVersePosition(verseId);
+    },
+    [syncParagraphVersePosition]
+  );
+
+  const createShabadLayoutHandler = useCallback(
+    (shabadIndex: number) => (event: LayoutChangeEvent) => {
+      const { y } = event.nativeEvent.layout;
+      paragraphOffsets.current.set(shabadIndex, y);
+
+      paragraphVerseLayouts.current.forEach((layout, verseId) => {
+        if (layout.shabadIndex === shabadIndex) {
+          syncParagraphVersePosition(verseId);
+        }
+      });
+    },
+    [syncParagraphVersePosition]
+  );
+
+  const clearMeasuredVerses = useCallback(
+    (resetCenterVerse = false) => {
+      versePositions.current.clear();
+      paragraphOffsets.current.clear();
+      paragraphVerseLayouts.current.clear();
+      hasScrolledToVerse.current = false;
+
+      if (resetCenterVerse) {
+        setCenterVerseId?.(0);
+      }
+    },
+    [setCenterVerseId]
+  );
+
+  const handleViewportLayout = useCallback((event: LayoutChangeEvent) => {
+    viewportHeight.current = event.nativeEvent.layout.height;
+  }, []);
+
+  const requestRecenter = useCallback(
+    (verseId?: number) => {
+      if (!verseId) {
+        return;
+      }
+
+      hasScrolledToVerse.current = false;
+      requestAnimationFrame(() => {
+        if (!hasScrolledToVerse.current) {
+          recenterVerse(verseId);
+        }
+      });
+    },
+    [recenterVerse]
+  );
+
+  return {
+    clearMeasuredVerses,
+    createLayoutHandler,
+    createParagraphVerseLayoutHandler,
+    createShabadLayoutHandler,
+    findCenterVerseId,
+    handleViewportLayout,
+    requestRecenter,
+  };
+};

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -72,6 +72,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   const previousFontSize = useRef<number>(18);
   const previousParagraphMode = useRef<boolean>(false);
   const [scrollToVerseId, setScrollToVerseId] = useState<number>(0);
+  const [scrollToVerseRequestKey, setScrollToVerseRequestKey] = useState<number>(0);
   const completionUndoPendingRef = useRef<boolean>(false);
   // Baseline scroll Y captured when completion guard starts; used to measure
   // upward movement and undo completion only after user scrolls up > 200px.
@@ -529,22 +530,20 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   useEffect(() => {
     const fontSizeChanged = fontSize !== previousFontSize.current;
     const paragraphModeChanged = isParagraphMode !== previousParagraphMode.current;
+    const verseIdToCenter =
+      centerVerseId || savedPathVerseId || matchedPath.current?.saveData.verseId || 0;
 
-    if ((fontSizeChanged || paragraphModeChanged) && pathContent?.page && centerVerseId !== 0) {
+    if (
+      (fontSizeChanged || paragraphModeChanged) &&
+      verseIdToCenter !== 0 &&
+      pathContent?.page?.some((page: any) => page.verseId === verseIdToCenter)
+    ) {
       previousFontSize.current = fontSize;
       previousParagraphMode.current = isParagraphMode;
-
-      // Calculate the verse index to know how much content is above
-      const verseIndex = pathContent.page.findIndex((page: any) => page.verseId === centerVerseId);
-
-      if (verseIndex !== -1 && scrollRef.current) {
-        // Wait for layout to complete with new font size, then scroll to the verse
-        setTimeout(() => {
-          setScrollToVerseId(centerVerseId);
-        }, 200);
-      }
+      setScrollToVerseId(verseIdToCenter);
+      setScrollToVerseRequestKey((currentKey) => currentKey + 1);
     }
-  }, [fontSize, isParagraphMode, pathContent, centerVerseId]);
+  }, [fontSize, isParagraphMode, pathContent, centerVerseId, savedPathVerseId]);
   useFocusEffect(
     useCallback(() => {
       const onBackPress = () => {
@@ -624,6 +623,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
           onSaveCommit={commitSavedPathState}
           setCenterVerseId={setCenterVerseId}
           scrollToVerseId={scrollToVerseId}
+          scrollToVerseRequestKey={scrollToVerseRequestKey}
           scrolledToSavedPath={scrolledToSavedPath}
           onScrollEndDrag={handleScrollEnd}
         />

--- a/utils/pathTextHelpers.ts
+++ b/utils/pathTextHelpers.ts
@@ -147,6 +147,7 @@ export const pathTextPropsAreEqual = (
     prevProps.fontSize === nextProps.fontSize &&
     prevProps.isVishraam === nextProps.isVishraam &&
     prevProps.vishraamsSource === nextProps.vishraamsSource &&
-    prevProps.vishraamsStyle === nextProps.vishraamsStyle
+    prevProps.vishraamsStyle === nextProps.vishraamsStyle &&
+    prevProps.onLayout === nextProps.onLayout
   );
 };


### PR DESCRIPTION
# Problem 
- The reading position was inconsistent after changing font size and returning from Settings.
- In line mode, the app could keep the old raw scroll offset instead of restoring the same centered  verse.
- In paragraph mode, centering was unreliable because verse position tracking was not stable enough across re-layouts.
- 
# Solution
-  Unified centering behavior so both line mode and paragraph mode use the same center-verse restore flow.
- Made verse-position measurement and recenter timing reliable during layout updates (including font- size changes).
- Updated restore logic to recenter by verse anchor (with fallback to saved verse) instead of relying on stale scroll offset.
- Simplified and organized centering logic into reusable paths while preserving existing save/progress
    behavior.

# Implementation
Issue in code (before):
  - centerVerseId restore depended on fragile timing.
  - Recenter could run before verse measurements were available, so it missed and stayed at previous
    scroll offset.
  - Paragraph mode did not produce stable absolute verse positions for centering, so center restore was
    inconsistent there.
  - Recenter triggering relied on timeout-style forcing, which was not deterministic across layout/font
    changes.
  - Memoized verse rows could keep stale layout handlers, which blocked measurement updates in some
    cases.

Fixed:
 - Recenter now uses measured verse position as the source of truth, not raw scroll offset.
  - Measurement lifecycle was made reliable around page/font/mode re-layout, so recenter runs when
    positions are actually usable.
  - Paragraph mode now resolves verse positions correctly for the scroll container, so center restore
    works like line mode.
  - Recenter triggering was made explicit and repeatable for the same target verse after layout changes.
  - Layout handler propagation was fixed for memoized verse components so measurement updates are not
    dropped.
