### PR TITLE
- Fixed the paragraph and larivaar mode

### DIFF
--- a/components/ParagraphTextForPath.tsx
+++ b/components/ParagraphTextForPath.tsx
@@ -18,6 +18,7 @@ type ParagraphTextForPathProps = PathTextProps & {
 
 const ParagraphTextForPathComponent = ({
   gurbaniLine,
+  renderWordSegments,
   onSelection,
   isSaving,
   pressIndex,
@@ -36,7 +37,6 @@ const ParagraphTextForPathComponent = ({
   isVishraam,
   vishraams,
   vishraamsSource,
-  originalVerse,
   onLayout,
   onTextLayout,
 }: ParagraphTextForPathProps) => {
@@ -118,9 +118,9 @@ const ParagraphTextForPathComponent = ({
         {isVishraam ? (
           <VishraamsText
             gurbaniLine={gurbaniLine}
+            renderWordSegments={renderWordSegments}
             vishraams={vishraams}
             vishraamsSource={vishraamsSource}
-            originalVerse={originalVerse}
           />
         ) : (
           gurbaniLine

--- a/components/PathReader.tsx
+++ b/components/PathReader.tsx
@@ -328,10 +328,11 @@ const PathReaderComponent = ({
     return pathContent?.page?.map((path: Verse, index: number) => {
       // Line mode can render directly from per-verse data because each verse is
       // already its own measurable block.
-      const larivaarRenderData = isLarivaar
-        ? getLarivaarRenderData(path.larivaar.unicode, path.verse.unicode)
-        : null;
-      const gurbaniLine = larivaarRenderData?.displayText ?? path.verse.unicode;
+      const larivaarRenderData =
+        isLarivaar && isVishraam
+          ? getLarivaarRenderData(path.larivaar.unicode, path.verse.unicode)
+          : null;
+      const gurbaniLine = isLarivaar ? path.larivaar.unicode : path.verse.unicode;
       const vishraam = path.visraam;
 
       return (

--- a/components/PathReader.tsx
+++ b/components/PathReader.tsx
@@ -230,6 +230,9 @@ const PathReaderComponent = ({
       return [];
     }
 
+    // Paragraph mode needs one prepared render model that both the visible
+    // text and the centering/layout code can share. Without that, larivaar
+    // wrapping, Vishraam segmentation, and measured verse positions can drift.
     return shabadsWithIndices.map((shabad) => ({
       startIndex: shabad.startIndex,
       verses: shabad.verses.map((verse) => {
@@ -271,6 +274,9 @@ const PathReaderComponent = ({
             <Text
               key={shabadIndex}
               onLayout={createShabadLayoutHandler(shabadIndex)}
+              // Measure the full rendered paragraph flow once, then derive each
+              // verse's vertical range from that shared layout. This is more
+              // stable than treating paragraph verses like independent blocks.
               onTextLayout={createParagraphVerseTextLayoutHandler(
                 shabadIndex,
                 shabad.verses.map(({ verse, renderedText }) => ({
@@ -320,6 +326,8 @@ const PathReaderComponent = ({
       );
     }
     return pathContent?.page?.map((path: Verse, index: number) => {
+      // Line mode can render directly from per-verse data because each verse is
+      // already its own measurable block.
       const larivaarRenderData = isLarivaar
         ? getLarivaarRenderData(path.larivaar.unicode, path.verse.unicode)
         : null;

--- a/components/PathReader.tsx
+++ b/components/PathReader.tsx
@@ -6,6 +6,7 @@ import { PathReaderStyles } from '@styles';
 import { PathNextAng } from './PathNextAng';
 import { usePathReaderCentering } from './usePathReaderCentering';
 import { trackEvent } from '@utils/analytics';
+import { getLarivaarRenderData, type LarivaarRenderData } from '@utils';
 import { PATH_DATA } from '@constants';
 import type { Verse, PathContent } from '@hooks';
 
@@ -53,7 +54,19 @@ interface PathReaderProps {
   scrollToVerseRequestKey?: number;
   scrolledToSavedPath: React.MutableRefObject<boolean>;
   onScrollEndDrag?: (scrollY: number) => void;
+  onContentSizeChange?: (width: number, height: number) => void;
 }
+
+type ParagraphVerseRender = {
+  verse: Verse;
+  renderedText: string;
+  renderWordSegments: string[] | null;
+};
+
+type ParagraphShabadRender = {
+  startIndex: number;
+  verses: ParagraphVerseRender[];
+};
 
 const PathReaderComponent = ({
   pathContent,
@@ -88,6 +101,7 @@ const PathReaderComponent = ({
   scrollToVerseRequestKey,
   scrolledToSavedPath,
   onScrollEndDrag,
+  onContentSizeChange,
 }: PathReaderProps) => {
   const {
     clearMeasuredVerses,
@@ -211,6 +225,36 @@ const PathReaderComponent = ({
     });
   }, [pathContent?.page]);
 
+  const paragraphShabads = useMemo<ParagraphShabadRender[]>(() => {
+    if (!isParagraphMode) {
+      return [];
+    }
+
+    return shabadsWithIndices.map((shabad) => ({
+      startIndex: shabad.startIndex,
+      verses: shabad.verses.map((verse) => {
+        if (!isLarivaar) {
+          return {
+            verse,
+            renderedText: verse.verse.unicode,
+            renderWordSegments: null,
+          };
+        }
+
+        const renderData: LarivaarRenderData = getLarivaarRenderData(
+          verse.larivaar.unicode,
+          verse.verse.unicode
+        );
+
+        return {
+          verse,
+          renderedText: renderData.displayText,
+          renderWordSegments: renderData.wordSegments,
+        };
+      }),
+    }));
+  }, [isParagraphMode, isLarivaar, shabadsWithIndices]);
+
   const paragraphShabadTextStyle = useMemo(
     () => ({
       marginBottom: 14,
@@ -223,63 +267,64 @@ const PathReaderComponent = ({
     if (isParagraphMode) {
       return (
         <View>
-          {shabadsWithIndices.map((shabad, shabadIndex) => (
+          {paragraphShabads.map((shabad, shabadIndex) => (
             <Text
               key={shabadIndex}
               onLayout={createShabadLayoutHandler(shabadIndex)}
               onTextLayout={createParagraphVerseTextLayoutHandler(
                 shabadIndex,
-                shabad.verses.map((verse) => ({
+                shabad.verses.map(({ verse, renderedText }) => ({
                   verseId: verse.verseId,
-                  text: `${isLarivaar ? verse.larivaar.unicode : verse.verse.unicode} `,
+                  text: `${renderedText} `,
                 }))
               )}
               style={paragraphShabadTextStyle}
             >
-              {shabad.verses.map((verse: Verse, verseIndex: number) => {
-                const gurbaniLine = isLarivaar ? verse.larivaar.unicode : verse.verse.unicode;
-                const vishraam = verse.visraam;
-                const originalVerse = verse.verse.unicode;
+              {shabad.verses.map(
+                ({ verse, renderedText, renderWordSegments }, verseIndex: number) => {
+                  const { verseId, visraam: vishraam } = verse;
+                  const globalIndex = shabad.startIndex + verseIndex + 1;
 
-                const globalIndex = shabad.startIndex + verseIndex + 1;
-
-                return (
-                  <ParagraphTextForPath
-                    key={`${verse.verseId}-${verseIndex}`}
-                    gurbaniLine={gurbaniLine}
-                    onSelection={createSelectionHandler(globalIndex - 1, verse.verseId)}
-                    onSave={createSaveHandler(verse.verseId)}
-                    onLayout={createParagraphVerseLayoutHandler(verse.verseId, shabadIndex)}
-                    isSaving={isSaving}
-                    pressIndex={pressIndex}
-                    index={globalIndex}
-                    verseId={verse.verseId}
-                    savedPathVerseId={savedPathVerseId}
-                    setIsSaving={setIsSaving}
-                    setIsSaved={setIsSaved}
-                    setPressIndex={setPressIndex}
-                    setSavedPathVerseId={setSavedPathVerseId}
-                    found={found}
-                    setFound={setFound}
-                    fontSize={fontSize}
-                    isSaved={isSaved}
-                    isVishraam={isVishraam}
-                    vishraams={vishraam}
-                    vishraamsSource={vishraamsSource}
-                    vishraamsStyle={vishraamsStyle}
-                    originalVerse={originalVerse}
-                  />
-                );
-              })}
+                  return (
+                    <ParagraphTextForPath
+                      key={`${verseId}-${verseIndex}`}
+                      gurbaniLine={renderedText}
+                      renderWordSegments={renderWordSegments}
+                      onSelection={createSelectionHandler(globalIndex - 1, verseId)}
+                      onSave={createSaveHandler(verseId)}
+                      onLayout={createParagraphVerseLayoutHandler(verseId, shabadIndex)}
+                      isSaving={isSaving}
+                      pressIndex={pressIndex}
+                      index={globalIndex}
+                      verseId={verseId}
+                      savedPathVerseId={savedPathVerseId}
+                      setIsSaving={setIsSaving}
+                      setIsSaved={setIsSaved}
+                      setPressIndex={setPressIndex}
+                      setSavedPathVerseId={setSavedPathVerseId}
+                      found={found}
+                      setFound={setFound}
+                      fontSize={fontSize}
+                      isSaved={isSaved}
+                      isVishraam={isVishraam}
+                      vishraams={vishraam}
+                      vishraamsSource={vishraamsSource}
+                      vishraamsStyle={vishraamsStyle}
+                    />
+                  );
+                }
+              )}
             </Text>
           ))}
         </View>
       );
     }
     return pathContent?.page?.map((path: Verse, index: number) => {
-      const gurbaniLine = isLarivaar ? path.larivaar.unicode : path.verse.unicode;
+      const larivaarRenderData = isLarivaar
+        ? getLarivaarRenderData(path.larivaar.unicode, path.verse.unicode)
+        : null;
+      const gurbaniLine = larivaarRenderData?.displayText ?? path.verse.unicode;
       const vishraam = path.visraam;
-      const originalVerse = path.verse.unicode;
 
       return (
         <SimpleTextForPath
@@ -303,9 +348,9 @@ const PathReaderComponent = ({
           isSaved={isSaved}
           isVishraam={isVishraam}
           vishraams={vishraam}
+          renderWordSegments={larivaarRenderData?.wordSegments}
           vishraamsSource={vishraamsSource}
           vishraamsStyle={vishraamsStyle}
-          originalVerse={originalVerse}
         />
       );
     });
@@ -331,7 +376,7 @@ const PathReaderComponent = ({
     paragraphShabadTextStyle,
     isSaved,
     isParagraphMode,
-    shabadsWithIndices,
+    paragraphShabads,
     isVishraam,
     vishraamsSource,
     vishraamsStyle,
@@ -369,6 +414,7 @@ const PathReaderComponent = ({
         onMoveShouldSetResponder={() => false}
         removeClippedSubviews={true}
         onLayout={handleViewportLayout}
+        onContentSizeChange={onContentSizeChange}
       >
         {pageContent}
         {pathContent?.source?.pageNo < PATH_DATA.LAST_ANG_NUMBER && !isNavigating && (

--- a/components/SimpleTextForPath.tsx
+++ b/components/SimpleTextForPath.tsx
@@ -16,6 +16,7 @@ import { VishraamsText } from './VishraamsText';
 
 const SimpleTextForPathComponent = ({
   gurbaniLine,
+  renderWordSegments,
   onSelection,
   isSaving,
   pressIndex,
@@ -34,7 +35,6 @@ const SimpleTextForPathComponent = ({
   isVishraam,
   vishraams,
   vishraamsSource,
-  originalVerse,
   onLayout,
 }: PathTextProps) => {
   const isLongPressingRef = useRef<boolean>(false);
@@ -85,9 +85,9 @@ const SimpleTextForPathComponent = ({
         {isVishraam ? (
           <VishraamsText
             gurbaniLine={gurbaniLine}
+            renderWordSegments={renderWordSegments}
             vishraams={vishraams}
             vishraamsSource={vishraamsSource}
-            originalVerse={originalVerse}
           />
         ) : (
           gurbaniLine

--- a/components/VishraamsText.tsx
+++ b/components/VishraamsText.tsx
@@ -18,6 +18,7 @@ export const VishraamsText: React.FC<VishraamsTextProps> = ({
   vishraamsSource = Constants.DEFAULT_VISHRAAM_SOURCE,
 }) => {
   const vishraamsData = vishraams?.[vishraamsSource as keyof Visraams] || [];
+  const isSegmentedLarivaar = !!(renderWordSegments && renderWordSegments.length > 1);
   const getMarker = (wordIndex: number) => vishraamsData.find((v) => v.p === wordIndex);
   const getWordTextElement = (word: string, wordIndex: number) => {
     const marker = getMarker(wordIndex);
@@ -42,12 +43,8 @@ export const VishraamsText: React.FC<VishraamsTextProps> = ({
     return <Text>{gurbaniLine}</Text>;
   }
 
-  const normalizedLine = gurbaniLine.replace(/\u200B/g, '');
-  const isLarivaar = !normalizedLine.includes(' ');
-  const words = isLarivaar
-    ? renderWordSegments && renderWordSegments.length > 1
-      ? renderWordSegments
-      : null
+  const words = isSegmentedLarivaar
+    ? renderWordSegments
     : gurbaniLine.split(' ').filter((w) => w.length > 0);
 
   if (!words || words.length <= 1) {
@@ -62,7 +59,7 @@ export const VishraamsText: React.FC<VishraamsTextProps> = ({
         return (
           <React.Fragment key={`frag-${wordIndex}`}>
             {element}
-            {wordIndex < words.length - 1 && <Text>{isLarivaar ? '\u200B' : ' '}</Text>}
+            {wordIndex < words.length - 1 && <Text>{isSegmentedLarivaar ? '\u200B' : ' '}</Text>}
           </React.Fragment>
         );
       })}

--- a/components/VishraamsText.tsx
+++ b/components/VishraamsText.tsx
@@ -1,95 +1,68 @@
 import React from 'react';
 import { Text } from 'react-native';
 import { VishraamsTheme } from '@constants/VishraamsTheme';
-import { VishraamsMarker, Visraams } from '@hooks/useLocal';
+import { Visraams } from '@hooks/useLocal';
 import { Constants } from '@constants/constant';
 
 type VishraamsTextProps = {
   gurbaniLine: string;
+  renderWordSegments?: string[] | null;
   vishraams: Visraams;
   vishraamsSource?: string;
-  originalVerse?: string;
 };
 
 export const VishraamsText: React.FC<VishraamsTextProps> = ({
   gurbaniLine,
+  renderWordSegments,
   vishraams,
   vishraamsSource = Constants.DEFAULT_VISHRAAM_SOURCE,
-  originalVerse,
 }) => {
   const vishraamsData = vishraams?.[vishraamsSource as keyof Visraams] || [];
+  const getMarker = (wordIndex: number) => vishraamsData.find((v) => v.p === wordIndex);
+  const getWordTextElement = (word: string, wordIndex: number) => {
+    const marker = getMarker(wordIndex);
+    if (!marker) {
+      return <Text key={`word-${wordIndex}`}>{word}</Text>;
+    }
+
+    return (
+      <Text
+        key={`word-${wordIndex}`}
+        style={{
+          color: marker.t === 'v' ? VishraamsTheme.mainPause.text : VishraamsTheme.lightPause.text,
+          fontWeight: VishraamsTheme.coloredWords.fontWeight,
+        }}
+      >
+        {word}
+      </Text>
+    );
+  };
 
   if (vishraamsData.length === 0) {
     return <Text>{gurbaniLine}</Text>;
   }
 
-  const isLarivaar = !gurbaniLine.includes(' ');
-  const referenceText = isLarivaar && originalVerse ? originalVerse : gurbaniLine;
-  const words = referenceText.split(' ').filter(w => w.length > 0);
+  const normalizedLine = gurbaniLine.replace(/\u200B/g, '');
+  const isLarivaar = !normalizedLine.includes(' ');
+  const words = isLarivaar
+    ? renderWordSegments && renderWordSegments.length > 1
+      ? renderWordSegments
+      : null
+    : gurbaniLine.split(' ').filter((w) => w.length > 0);
 
-  if (isLarivaar && originalVerse) {
-    let larivaarPos = 0;
-
-    return (
-      <>
-        {words.map((word, wordIndex) => {
-          const marker = vishraamsData.find((v: VishraamsMarker) => v.p === wordIndex);
-          const wordLength = word.length;
-          const wordText = gurbaniLine.substring(larivaarPos, larivaarPos + wordLength);
-
-          larivaarPos += wordLength;
-
-          if (marker) {
-            const isMainPause = marker.t === 'v';
-            const pauseConfig = isMainPause
-              ? VishraamsTheme.mainPause
-              : VishraamsTheme.lightPause;
-
-            return (
-              <Text
-                key={`word-${wordIndex}`}
-                style={{
-                  color: pauseConfig.text,
-                  fontWeight: VishraamsTheme.coloredWords.fontWeight,
-                }}
-              >
-                {wordText}
-              </Text>
-            );
-          }
-
-          return <Text key={`word-${wordIndex}`}>{wordText}</Text>;
-        })}
-      </>
-    );
+  if (!words || words.length <= 1) {
+    return <Text>{gurbaniLine}</Text>;
   }
 
   return (
     <>
       {words.map((word, wordIndex) => {
-        const marker = vishraamsData.find((v: VishraamsMarker) => v.p === wordIndex);
-
-        const element = marker ? (
-          <Text
-            key={`word-${wordIndex}`}
-            style={{
-              color:
-                marker.t === 'v'
-                  ? VishraamsTheme.mainPause.text
-                  : VishraamsTheme.lightPause.text,
-              fontWeight: VishraamsTheme.coloredWords.fontWeight,
-            }}
-          >
-            {word}
-          </Text>
-        ) : (
-          <Text key={`word-${wordIndex}`}>{word}</Text>
-        );
+        const element = getWordTextElement(word, wordIndex);
 
         return (
           <React.Fragment key={`frag-${wordIndex}`}>
             {element}
-            {wordIndex < words.length - 1 && <Text> </Text>}
+            {wordIndex < words.length - 1 && <Text>{isLarivaar ? '\u200B' : ' '}</Text>}
           </React.Fragment>
         );
       })}

--- a/hooks/usePathNavigation.ts
+++ b/hooks/usePathNavigation.ts
@@ -9,27 +9,27 @@ type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 interface UsePathNavigationProps {
   isAngNavigation: boolean;
   pathAng: number;
-  savedPathVerseId: number;
   pathId: number;
-  setIsSaved: (value: boolean) => void;
   setIsAngNavigation: (value: boolean) => void;
   updatePathAng: (angNumber: number) => void;
-  scrollOffset: React.MutableRefObject<number>;
   navigation: NavigationProp;
+  persistCurrentScroll: () => Promise<void>;
 }
 
 export const usePathNavigation = ({
   isAngNavigation,
   pathAng,
-  savedPathVerseId,
   pathId,
-  setIsSaved,
   setIsAngNavigation,
   updatePathAng,
-  scrollOffset,
   navigation,
+  persistCurrentScroll,
 }: UsePathNavigationProps) => {
-  const { fetchFromLocal, handleUpdatePath } = useLocal();
+  const { fetchFromLocal } = useLocal();
+  const persistAndGoHome = useCallback(async () => {
+    await persistCurrentScroll();
+    navigation.push('Home');
+  }, [persistCurrentScroll, navigation]);
 
   const handleGoBack = useCallback(async () => {
     if (isAngNavigation) {
@@ -39,10 +39,9 @@ export const usePathNavigation = ({
 
       if (pathAng !== lastSavedAngNumber) {
         showSaveProgressAlert({
-          onSaveAndGoBack: () => {
-            handleUpdatePath(pathId, pathAng, savedPathVerseId, scrollOffset.current, setIsSaved);
+          onSaveAndGoBack: async () => {
             setIsAngNavigation(false);
-            navigation.push('Home');
+            await persistAndGoHome();
           },
           onGoBackWithoutSaving: () => {
             updatePathAng(lastSavedAngNumber);
@@ -50,23 +49,20 @@ export const usePathNavigation = ({
           },
         });
       } else {
-        navigation.push('Home');
+        await persistAndGoHome();
       }
     } else {
-      navigation.push('Home');
+      await persistAndGoHome();
     }
   }, [
     isAngNavigation,
     pathAng,
-    handleUpdatePath,
     pathId,
-    savedPathVerseId,
-    setIsSaved,
+    persistAndGoHome,
     setIsAngNavigation,
     navigation,
     fetchFromLocal,
     updatePathAng,
-    scrollOffset,
   ]);
 
   return { handleGoBack };

--- a/hooks/useScrollToSavedPath.ts
+++ b/hooks/useScrollToSavedPath.ts
@@ -5,7 +5,7 @@ import { ErrorConstants } from '@constants';
 import { DateData } from '@hooks';
 
 interface UseScrollToSavedPathProps {
-  matchedPathDate: DateData | undefined;
+  matchedPathDateRef: React.MutableRefObject<DateData | undefined>;
   pathContent: any;
   savedPathVerseId: number;
   scrolledToSavedPath: React.MutableRefObject<boolean>;
@@ -19,7 +19,7 @@ interface UseScrollToSavedPathProps {
 }
 
 export const useScrollToSavedPath = ({
-  matchedPathDate,
+  matchedPathDateRef,
   pathContent,
   savedPathVerseId,
   scrolledToSavedPath,
@@ -51,17 +51,23 @@ export const useScrollToSavedPath = ({
   }, [fadeAnim, setFound, setIsSaving, setIsSaved]);
 
   const scrollToSavedPathData = useCallback(async () => {
-    if (matchedPathDate && !scrolledToSavedPath.current && scrollRef.current) {
-      scrollOffset.current = matchedPathDate.scrollPosition;
-      if (scrollRef.current) {
-        scrollRef.current.scrollTo({
-          y: scrollOffset.current,
-          animated: true,
-        });
-      }
+    const applyScroll = (y: number) => {
+      scrollOffset.current = y;
+      scrollRef.current?.scrollTo({
+        y,
+        animated: true,
+      });
       scrolledToSavedPath.current = true;
       fadeAnim.setValue(1);
       runFadeSequence();
+    };
+
+    // Read the ref at call time so we always get the latest value, not the
+    // value captured when the hook was first invoked.
+    const matchedPathDate = matchedPathDateRef.current;
+    if (matchedPathDate && !scrolledToSavedPath.current && scrollRef.current) {
+      applyScroll(matchedPathDate.scrollPosition);
+      return;
     }
 
     if (pathContent && !scrolledToSavedPath.current) {
@@ -82,23 +88,14 @@ export const useScrollToSavedPath = ({
           scrollHeight = 150;
         }
         if (scrollIndex !== -1) {
-          scrollOffset.current = scrollIndex * scrollHeight;
-          if (scrollRef.current) {
-            scrollRef.current.scrollTo({
-              y: scrollOffset.current,
-              animated: true,
-            });
-          }
-          scrolledToSavedPath.current = true;
-          fadeAnim.setValue(1);
-          runFadeSequence();
+          applyScroll(scrollIndex * scrollHeight);
         }
       } catch (error) {
         showErrorAlert(ErrorConstants.ERROR_SCROLLING_TO_SAVED_PATH);
       }
     }
   }, [
-    matchedPathDate,
+    matchedPathDateRef,
     pathContent,
     savedPathVerseId,
     scrolledToSavedPath,

--- a/hooks/useScrollToSavedPath.ts
+++ b/hooks/useScrollToSavedPath.ts
@@ -51,23 +51,19 @@ export const useScrollToSavedPath = ({
   }, [fadeAnim, setFound, setIsSaving, setIsSaved]);
 
   const scrollToSavedPathData = useCallback(async () => {
-    const applyScroll = (y: number) => {
-      scrollOffset.current = y;
-      scrollRef.current?.scrollTo({
-        y,
-        animated: true,
-      });
+    const matchedPathDate = matchedPathDateRef.current;
+
+    if (matchedPathDate && !scrolledToSavedPath.current && scrollRef.current) {
+      scrollOffset.current = matchedPathDate.scrollPosition;
+      if (scrollRef.current) {
+        scrollRef.current.scrollTo({
+          y: scrollOffset.current,
+          animated: true,
+        });
+      }
       scrolledToSavedPath.current = true;
       fadeAnim.setValue(1);
       runFadeSequence();
-    };
-
-    // Read the ref at call time so we always get the latest value, not the
-    // value captured when the hook was first invoked.
-    const matchedPathDate = matchedPathDateRef.current;
-    if (matchedPathDate && !scrolledToSavedPath.current && scrollRef.current) {
-      applyScroll(matchedPathDate.scrollPosition);
-      return;
     }
 
     if (pathContent && !scrolledToSavedPath.current) {
@@ -88,7 +84,16 @@ export const useScrollToSavedPath = ({
           scrollHeight = 150;
         }
         if (scrollIndex !== -1) {
-          applyScroll(scrollIndex * scrollHeight);
+          scrollOffset.current = scrollIndex * scrollHeight;
+          if (scrollRef.current) {
+            scrollRef.current.scrollTo({
+              y: scrollOffset.current,
+              animated: true,
+            });
+          }
+          scrolledToSavedPath.current = true;
+          fadeAnim.setValue(1);
+          runFadeSequence();
         }
       } catch (error) {
         showErrorAlert(ErrorConstants.ERROR_SCROLLING_TO_SAVED_PATH);

--- a/hooks/useScrollToSavedPath.ts
+++ b/hooks/useScrollToSavedPath.ts
@@ -5,7 +5,7 @@ import { ErrorConstants } from '@constants';
 import { DateData } from '@hooks';
 
 interface UseScrollToSavedPathProps {
-  matchedPathDateRef: React.MutableRefObject<DateData | undefined>;
+  matchedPathDate: DateData | undefined;
   pathContent: any;
   savedPathVerseId: number;
   scrolledToSavedPath: React.MutableRefObject<boolean>;
@@ -19,7 +19,7 @@ interface UseScrollToSavedPathProps {
 }
 
 export const useScrollToSavedPath = ({
-  matchedPathDateRef,
+  matchedPathDate,
   pathContent,
   savedPathVerseId,
   scrolledToSavedPath,
@@ -51,8 +51,6 @@ export const useScrollToSavedPath = ({
   }, [fadeAnim, setFound, setIsSaving, setIsSaved]);
 
   const scrollToSavedPathData = useCallback(async () => {
-    const matchedPathDate = matchedPathDateRef.current;
-
     if (matchedPathDate && !scrolledToSavedPath.current && scrollRef.current) {
       scrollOffset.current = matchedPathDate.scrollPosition;
       if (scrollRef.current) {
@@ -100,7 +98,7 @@ export const useScrollToSavedPath = ({
       }
     }
   }, [
-    matchedPathDateRef,
+    matchedPathDate,
     pathContent,
     savedPathVerseId,
     scrolledToSavedPath,

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -69,6 +69,8 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   const fadeAnim = useRef(new Animated.Value(1));
   const debounceAnimValueRef = useRef(new Animated.Value(0));
   const [fontSize, setFontSize] = useState<number>(18);
+  const [displaySettingsLoaded, setDisplaySettingsLoaded] = useState<boolean>(false);
+  const [readerContentHeight, setReaderContentHeight] = useState<number>(0);
   const previousFontSize = useRef<number>(18);
   const previousParagraphMode = useRef<boolean>(false);
   const [scrollToVerseId, setScrollToVerseId] = useState<number>(0);
@@ -77,6 +79,13 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   // Baseline scroll Y captured when completion guard starts; used to measure
   // upward movement and undo completion only after user scrolls up > 200px.
   const completionUndoStartScrollYRef = useRef<number | null>(null);
+
+  const resetTransientUiState = useCallback(() => {
+    setIsSaving(false);
+    setIsSaved(false);
+    setPressIndex(0);
+    setFound(false);
+  }, []);
 
   const pathPujabiAng = useMemo(
     () =>
@@ -107,13 +116,12 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   const fetchFromBaniDB = useCallback(
     async (angNumber: number) => {
       alertIndicator.current = <ActivityIndicator size={'large'} color={'#000'} />;
+      setReaderContentHeight(0);
       const pathFromBaniDB = await BaniDB(angNumber);
+      alertIndicator.current = undefined;
       setPathContent(pathFromBaniDB.data);
       setRetryState({ needsRetry: false, lastFailedAng: null });
-      setIsSaving(false);
-      setIsSaved(false);
-      setPressIndex(0);
-      setFound(false);
+      resetTransientUiState();
       if (pathFromBaniDB.success === false) {
         const isConnected = await checkNetwork();
         if (!isConnected) {
@@ -126,7 +134,6 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
           return;
         }
       }
-      alertIndicator.current = undefined;
       const currentDebounceTimer = debounceTimer.current;
       if (currentDebounceTimer) {
         clearTimeout(currentDebounceTimer);
@@ -138,7 +145,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
         animated: false,
       });
     },
-    [checkNetwork, navigation]
+    [checkNetwork, navigation, resetTransientUiState]
   );
 
   const { handleRightArrow, handleLeftArrow } = useNavigation({
@@ -299,7 +306,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   );
 
   const { scrollToSavedPathData } = useScrollToSavedPath({
-    matchedPathDate: matchedPathDate.current,
+    matchedPathDateRef: matchedPathDate,
     pathContent,
     savedPathVerseId,
     scrolledToSavedPath,
@@ -312,30 +319,64 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     fetchFontSize,
   });
 
-  const updatePathAng = useCallback((angNumber: number) => {
-    setPathAng(angNumber);
-    setIsSaving(false);
-    setIsSaved(false);
-    setPressIndex(0);
-    setFound(false);
-    setSavedAngNumber(angNumber);
-    if (angNumber !== PATH_DATA.LAST_ANG_NUMBER) {
-      completionUndoPendingRef.current = false;
-      completionUndoStartScrollYRef.current = null;
+  const updatePathAng = useCallback(
+    (angNumber: number) => {
+      setPathAng(angNumber);
+      resetTransientUiState();
+      setSavedAngNumber(angNumber);
+      if (angNumber !== PATH_DATA.LAST_ANG_NUMBER) {
+        completionUndoPendingRef.current = false;
+        completionUndoStartScrollYRef.current = null;
+      }
+    },
+    [resetTransientUiState]
+  );
+
+  const persistCurrentScrollPosition = useCallback(async () => {
+    if (!pathAng) {
+      return;
     }
-  }, []);
+
+    try {
+      const verseIdToKeep = matchedPath.current?.saveData.verseId || savedPathVerseId;
+      await handleUpdatePath(
+        route.params.pathId,
+        pathAng,
+        verseIdToKeep,
+        scrollOffset.current,
+        () => {}
+      );
+      commitSavedPathState(pathAng, verseIdToKeep, scrollOffset.current);
+    } catch (error) {
+      // Leaving the screen should not be blocked by a background scroll-position save.
+    }
+  }, [
+    handleUpdatePath,
+    route.params.pathId,
+    pathAng,
+    savedPathVerseId,
+    scrollOffset,
+    commitSavedPathState,
+  ]);
 
   const { handleGoBack } = usePathNavigation({
     isAngNavigation,
     pathAng,
-    savedPathVerseId,
     pathId: route.params.pathId,
-    setIsSaved,
     setIsAngNavigation,
     updatePathAng,
-    scrollOffset,
     navigation,
+    persistCurrentScroll: persistCurrentScrollPosition,
   });
+
+  const handlePathDrawerNavigate = useCallback(
+    async (targetRoute: string, targetPathId?: number) => {
+      await persistCurrentScrollPosition();
+      handleDrawerNavigate(targetRoute, targetPathId);
+    },
+    [persistCurrentScrollPosition, handleDrawerNavigate]
+  );
+
   const handleAngsRightArrow = useCallback(() => {
     handleRightArrow(pathAng);
   }, [handleRightArrow, pathAng]);
@@ -343,6 +384,10 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   const handleAngsLeftArrow = useCallback(() => {
     handleLeftArrow(pathAng);
   }, [handleLeftArrow, pathAng]);
+
+  const handleReaderContentSizeChange = useCallback((_: number, height: number) => {
+    setReaderContentHeight((currentHeight) => (currentHeight === height ? currentHeight : height));
+  }, []);
 
   const savingMessage = useMemo(
     () =>
@@ -352,10 +397,47 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     [isSaved]
   );
 
+  const loadDisplaySettings = useCallback(async () => {
+    try {
+      const [larivaar, format, paragraphMode, vishraam, vishraamsSourceData, fontSizeData] =
+        await Promise.all([
+          fetchLarivaar(),
+          fetchAngsFormat(),
+          fetchParagraphMode(),
+          fetchVishraam(),
+          fetchVishraamsSource(),
+          fetchFontSize(),
+        ]);
+
+      const nextParagraphMode = paragraphMode || false;
+      const nextFontSize = fontSizeData.number;
+
+      setIsLarivaar(larivaar || false);
+      setAngsFormat(format);
+      setIsParagraphMode(nextParagraphMode);
+      setIsVishraam(vishraam || false);
+      setVishraamsSource(vishraamsSourceData?.source || Constants.DEFAULT_VISHRAAM_SOURCE);
+      setFontSize(nextFontSize);
+      return { fontSize: nextFontSize, paragraphMode: nextParagraphMode };
+    } catch (error) {
+      setIsLarivaar(false);
+      setAngsFormat({ format: 'Punjabi' });
+      setIsParagraphMode(false);
+      setIsVishraam(false);
+      setFontSize(18);
+      return { fontSize: 18, paragraphMode: false };
+    } finally {
+      setDisplaySettingsLoaded(true);
+    }
+  }, []);
+
   useEffect(() => {
     scrolledToSavedPath.current = false;
     const fetchPath = async () => {
       try {
+        const settings = await loadDisplaySettings();
+        previousFontSize.current = settings.fontSize;
+        previousParagraphMode.current = settings.paragraphMode;
         const { pathDataArray, pathDateDataArray } = await fetchFromLocal();
         const matchedPathData = pathDataArray.find(
           (path: PathData) => path.pathId === route.params.pathId
@@ -455,75 +537,42 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     };
   }, [isSaved, found]);
 
-  const scrollAnimValueRef = useRef(new Animated.Value(0));
-
   useEffect(() => {
-    let animation: Animated.CompositeAnimation | null = null;
-    if (pathAng === matchedPath.current?.saveData.angNumber && pathContent) {
-      scrollAnimValueRef.current.setValue(0);
-      animation = Animated.timing(scrollAnimValueRef.current, {
-        toValue: 1,
-        duration: 10,
-        useNativeDriver: true,
-      });
-      animation.start(() => {
+    const savedScrollPosition = matchedPathDate.current?.scrollPosition || 0;
+    const isSavedAng = pathAng === matchedPath.current?.saveData.angNumber;
+    const hasEnoughContentForSavedScroll =
+      savedScrollPosition === 0 || readerContentHeight > savedScrollPosition;
+
+    if (!displaySettingsLoaded || !isSavedAng || !pathContent || !hasEnoughContentForSavedScroll) {
+      return;
+    }
+
+    let firstFrame: number | null = null;
+    let secondFrame: number | null = null;
+
+    firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => {
         scrollToSavedPathData();
       });
-    }
+    });
+
     return () => {
-      if (animation) {
-        animation.stop();
+      if (firstFrame !== null) {
+        cancelAnimationFrame(firstFrame);
+      }
+      if (secondFrame !== null) {
+        cancelAnimationFrame(secondFrame);
       }
     };
-  }, [pathAng, pathContent, scrollToSavedPathData]);
+  }, [pathAng, pathContent, readerContentHeight, displaySettingsLoaded, scrollToSavedPathData]);
 
   useFocusEffect(
     useCallback(() => {
-      const fetchData = async () => {
-        try {
-          const [larivaar, format, paragraphMode, vishraam, vishraamsSourceData] =
-            await Promise.all([
-              fetchLarivaar(),
-              fetchAngsFormat(),
-              fetchParagraphMode(),
-              fetchVishraam(),
-              fetchVishraamsSource(),
-            ]);
-          setIsLarivaar(larivaar || false);
-          setAngsFormat(format);
-          setIsParagraphMode(paragraphMode || false);
-          setIsVishraam(vishraam || false);
-          setVishraamsSource(vishraamsSourceData?.source || Constants.DEFAULT_VISHRAAM_SOURCE);
-        } catch (error) {
-          setIsLarivaar(false);
-          setAngsFormat({ format: 'Punjabi' });
-          setIsParagraphMode(false);
-          setIsVishraam(false);
-        }
-      };
-      fetchData();
-    }, [
-      fetchLarivaar,
-      fetchAngsFormat,
-      fetchParagraphMode,
-      fetchVishraam,
-      fetchVishraamsSource,
-      pathAng,
-    ])
-  );
-  useFocusEffect(
-    useCallback(() => {
-      const fetch = async () => {
-        try {
-          const fontSizeData = await fetchFontSize();
-          setFontSize(fontSizeData.number);
-        } catch (e) {
-          showErrorAlert(ErrorConstants.FAILED_TO_LOAD_FONT_SIZE);
-          setFontSize(18);
-        }
-      };
-      fetch();
-    }, [fetchFontSize])
+      if (!displaySettingsLoaded) {
+        return;
+      }
+      loadDisplaySettings();
+    }, [loadDisplaySettings, displaySettingsLoaded])
   );
 
   // Maintain scroll position when font size or paragraph mode changes
@@ -626,6 +675,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
           scrollToVerseRequestKey={scrollToVerseRequestKey}
           scrolledToSavedPath={scrolledToSavedPath}
           onScrollEndDrag={handleScrollEnd}
+          onContentSizeChange={handleReaderContentSizeChange}
         />
         {alertIndicator.current !== undefined ? (
           <Loading
@@ -663,7 +713,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
         <DrawerMenu
           isVisible={isDrawerVisible}
           onClose={() => setIsDrawerVisible(false)}
-          onNavigate={handleDrawerNavigate}
+          onNavigate={handlePathDrawerNavigate}
           currentRoute={Routes.Path}
           pathId={route.params.pathId}
           onGoToAngPress={() => setIsAngsNavigationVisible(true)}

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -69,7 +69,6 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   const fadeAnim = useRef(new Animated.Value(1));
   const debounceAnimValueRef = useRef(new Animated.Value(0));
   const [fontSize, setFontSize] = useState<number>(18);
-  const [displaySettingsLoaded, setDisplaySettingsLoaded] = useState<boolean>(false);
   const [readerContentHeight, setReaderContentHeight] = useState<number>(0);
   const previousFontSize = useRef<number>(18);
   const previousParagraphMode = useRef<boolean>(false);
@@ -397,47 +396,42 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     [isSaved]
   );
 
-  const loadDisplaySettings = useCallback(async () => {
-    try {
-      const [larivaar, format, paragraphMode, vishraam, vishraamsSourceData, fontSizeData] =
-        await Promise.all([
-          fetchLarivaar(),
-          fetchAngsFormat(),
-          fetchParagraphMode(),
-          fetchVishraam(),
-          fetchVishraamsSource(),
-          fetchFontSize(),
-        ]);
-
-      const nextParagraphMode = paragraphMode || false;
-      const nextFontSize = fontSizeData.number;
-
-      setIsLarivaar(larivaar || false);
-      setAngsFormat(format);
-      setIsParagraphMode(nextParagraphMode);
-      setIsVishraam(vishraam || false);
-      setVishraamsSource(vishraamsSourceData?.source || Constants.DEFAULT_VISHRAAM_SOURCE);
-      setFontSize(nextFontSize);
-      return { fontSize: nextFontSize, paragraphMode: nextParagraphMode };
-    } catch (error) {
-      setIsLarivaar(false);
-      setAngsFormat({ format: 'Punjabi' });
-      setIsParagraphMode(false);
-      setIsVishraam(false);
-      setFontSize(18);
-      return { fontSize: 18, paragraphMode: false };
-    } finally {
-      setDisplaySettingsLoaded(true);
-    }
-  }, []);
-
   useEffect(() => {
     scrolledToSavedPath.current = false;
     const fetchPath = async () => {
       try {
-        const settings = await loadDisplaySettings();
-        previousFontSize.current = settings.fontSize;
-        previousParagraphMode.current = settings.paragraphMode;
+        try {
+          const [larivaar, format, paragraphMode, vishraam, vishraamsSourceData, fontSizeData] =
+            await Promise.all([
+              fetchLarivaar(),
+              fetchAngsFormat(),
+              fetchParagraphMode(),
+              fetchVishraam(),
+              fetchVishraamsSource(),
+              fetchFontSize(),
+            ]);
+
+          const nextParagraphMode = paragraphMode || false;
+          const nextFontSize = fontSizeData.number;
+
+          setIsLarivaar(larivaar || false);
+          setAngsFormat(format);
+          setIsParagraphMode(nextParagraphMode);
+          setIsVishraam(vishraam || false);
+          setVishraamsSource(vishraamsSourceData?.source || Constants.DEFAULT_VISHRAAM_SOURCE);
+          setFontSize(nextFontSize);
+          previousFontSize.current = nextFontSize;
+          previousParagraphMode.current = nextParagraphMode;
+        } catch (error) {
+          setIsLarivaar(false);
+          setAngsFormat({ format: 'Punjabi' });
+          setIsParagraphMode(false);
+          setIsVishraam(false);
+          setFontSize(18);
+          previousFontSize.current = 18;
+          previousParagraphMode.current = false;
+        }
+
         const { pathDataArray, pathDateDataArray } = await fetchFromLocal();
         const matchedPathData = pathDataArray.find(
           (path: PathData) => path.pathId === route.params.pathId
@@ -543,7 +537,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     const hasEnoughContentForSavedScroll =
       savedScrollPosition === 0 || readerContentHeight > savedScrollPosition;
 
-    if (!displaySettingsLoaded || !isSavedAng || !pathContent || !hasEnoughContentForSavedScroll) {
+    if (!isSavedAng || !pathContent || !hasEnoughContentForSavedScroll) {
       return;
     }
 
@@ -564,15 +558,39 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
         cancelAnimationFrame(secondFrame);
       }
     };
-  }, [pathAng, pathContent, readerContentHeight, displaySettingsLoaded, scrollToSavedPathData]);
+  }, [pathAng, pathContent, readerContentHeight, scrollToSavedPathData]);
 
   useFocusEffect(
     useCallback(() => {
-      if (!displaySettingsLoaded) {
-        return;
-      }
-      loadDisplaySettings();
-    }, [loadDisplaySettings, displaySettingsLoaded])
+      const refreshDisplaySettings = async () => {
+        try {
+          const [larivaar, format, paragraphMode, vishraam, vishraamsSourceData, fontSizeData] =
+            await Promise.all([
+              fetchLarivaar(),
+              fetchAngsFormat(),
+              fetchParagraphMode(),
+              fetchVishraam(),
+              fetchVishraamsSource(),
+              fetchFontSize(),
+            ]);
+
+          setIsLarivaar(larivaar || false);
+          setAngsFormat(format);
+          setIsParagraphMode(paragraphMode || false);
+          setIsVishraam(vishraam || false);
+          setVishraamsSource(vishraamsSourceData?.source || Constants.DEFAULT_VISHRAAM_SOURCE);
+          setFontSize(fontSizeData.number);
+        } catch (error) {
+          setIsLarivaar(false);
+          setAngsFormat({ format: 'Punjabi' });
+          setIsParagraphMode(false);
+          setIsVishraam(false);
+          setFontSize(18);
+        }
+      };
+
+      refreshDisplaySettings();
+    }, [])
   );
 
   // Maintain scroll position when font size or paragraph mode changes

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -400,6 +400,10 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
     scrolledToSavedPath.current = false;
     const fetchPath = async () => {
       try {
+        // Paragraph mode, larivaar, vishraam, and font size all change the rendered
+        // text flow. We load them before fetching/opening the saved ang so the first
+        // restore uses the final layout instead of restoring scroll against defaults
+        // and then reflowing to a different position.
         try {
           const [larivaar, format, paragraphMode, vishraam, vishraamsSourceData, fontSizeData] =
             await Promise.all([

--- a/screens/PathScreen.tsx
+++ b/screens/PathScreen.tsx
@@ -306,7 +306,7 @@ export const PathScreen = React.memo(({ navigation, route }: PathScreenProps) =>
   );
 
   const { scrollToSavedPathData } = useScrollToSavedPath({
-    matchedPathDateRef: matchedPathDate,
+    matchedPathDate: matchedPathDate.current,
     pathContent,
     savedPathVerseId,
     scrolledToSavedPath,

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -10,6 +10,8 @@ export {
   useContainerStyle,
   createLongPressHandler,
   createPressHandler,
+  getLarivaarRenderData,
   pathTextPropsAreEqual,
+  type LarivaarRenderData,
   type PathTextProps,
 } from './pathTextHelpers';

--- a/utils/pathTextHelpers.ts
+++ b/utils/pathTextHelpers.ts
@@ -78,95 +78,25 @@ export type LarivaarRenderData = {
 
 const ZERO_WIDTH_SPACE = '\u200B';
 
-const getGraphemes = (text: string): string[] => {
-  const { Segmenter } = Intl as { Segmenter?: any };
-  if (Segmenter) {
-    return Array.from(
-      new Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
-      ({ segment }) => segment
-    );
-  }
-
-  return Array.from(text);
-};
-
-// Larivaar text has no visible spaces, so paragraph mode needs explicit wrap
-// opportunities. Joining grapheme clusters with zero-width spaces preserves the
-// visual text while still letting React Native wrap it.
-const buildGraphemeWrappedText = (text: string) => getGraphemes(text).join(ZERO_WIDTH_SPACE);
-
 const splitWords = (text?: string): string[] =>
   text ? text.trim().split(/\s+/).filter(Boolean) : [];
-
-const buildAlignedLarivaarSegments = (
-  larivaar: string,
-  originalVerse?: string
-): string[] | null => {
-  const originalWords = splitWords(originalVerse);
-  if (originalWords.length <= 1) {
-    return null;
-  }
-
-  // When the spaced verse and larivaar text still match at the grapheme-count
-  // level, we can project word boundaries onto larivaar and keep Vishraam
-  // word indices meaningful. If that mapping does not line up exactly, callers
-  // must fall back to grapheme-only wrapping instead of forcing bad segments.
-  const originalWordLengths = originalWords.map((word) => getGraphemes(word).length);
-  const larivaarGraphemes = getGraphemes(larivaar);
-  if (larivaarGraphemes.length === 0) {
-    return null;
-  }
-
-  const segments: string[] = [];
-  let cursor = 0;
-
-  for (let index = 0; index < originalWordLengths.length; index += 1) {
-    const length = originalWordLengths[index];
-    if (length <= 0) {
-      return null;
-    }
-
-    const end = cursor + length;
-    if (end > larivaarGraphemes.length) {
-      return null;
-    }
-
-    const segment = larivaarGraphemes.slice(cursor, end).join('');
-    if (!segment) {
-      return null;
-    }
-
-    segments.push(segment);
-    cursor = end;
-  }
-
-  // Any remaining graphemes mean source and target are misaligned.
-  if (cursor !== larivaarGraphemes.length) {
-    return null;
-  }
-
-  return segments.length > 1 ? segments : null;
-};
 
 export const getLarivaarRenderData = (
   larivaar: string,
   originalVerse?: string
 ): LarivaarRenderData => {
-  const wordSegments = buildAlignedLarivaarSegments(larivaar, originalVerse);
+  const originalWords = splitWords(originalVerse);
+  const collapsedOriginal = originalWords.join('');
 
-  // Prefer aligned word segments when they are provably valid so paragraph
-  // rendering and Vishraam styling share the same segmentation model.
-  if (wordSegments && wordSegments.length > 1) {
+  if (originalWords.length > 1 && collapsedOriginal === larivaar) {
     return {
-      displayText: wordSegments.join(ZERO_WIDTH_SPACE),
-      wordSegments,
+      displayText: originalWords.join(ZERO_WIDTH_SPACE),
+      wordSegments: originalWords,
     };
   }
 
-  // Fallback keeps paragraph wrapping working even when we cannot safely map
-  // the spaced verse onto larivaar word boundaries.
   return {
-    displayText: buildGraphemeWrappedText(larivaar),
+    displayText: larivaar,
     wordSegments: null,
   };
 };

--- a/utils/pathTextHelpers.ts
+++ b/utils/pathTextHelpers.ts
@@ -90,6 +90,9 @@ const getGraphemes = (text: string): string[] => {
   return Array.from(text);
 };
 
+// Larivaar text has no visible spaces, so paragraph mode needs explicit wrap
+// opportunities. Joining grapheme clusters with zero-width spaces preserves the
+// visual text while still letting React Native wrap it.
 const buildGraphemeWrappedText = (text: string) => getGraphemes(text).join(ZERO_WIDTH_SPACE);
 
 const splitWords = (text?: string): string[] =>
@@ -104,6 +107,10 @@ const buildAlignedLarivaarSegments = (
     return null;
   }
 
+  // When the spaced verse and larivaar text still match at the grapheme-count
+  // level, we can project word boundaries onto larivaar and keep Vishraam
+  // word indices meaningful. If that mapping does not line up exactly, callers
+  // must fall back to grapheme-only wrapping instead of forcing bad segments.
   const originalWordLengths = originalWords.map((word) => getGraphemes(word).length);
   const larivaarGraphemes = getGraphemes(larivaar);
   if (larivaarGraphemes.length === 0) {
@@ -147,6 +154,8 @@ export const getLarivaarRenderData = (
 ): LarivaarRenderData => {
   const wordSegments = buildAlignedLarivaarSegments(larivaar, originalVerse);
 
+  // Prefer aligned word segments when they are provably valid so paragraph
+  // rendering and Vishraam styling share the same segmentation model.
   if (wordSegments && wordSegments.length > 1) {
     return {
       displayText: wordSegments.join(ZERO_WIDTH_SPACE),
@@ -154,6 +163,8 @@ export const getLarivaarRenderData = (
     };
   }
 
+  // Fallback keeps paragraph wrapping working even when we cannot safely map
+  // the spaced verse onto larivaar word boundaries.
   return {
     displayText: buildGraphemeWrappedText(larivaar),
     wordSegments: null,

--- a/utils/pathTextHelpers.ts
+++ b/utils/pathTextHelpers.ts
@@ -8,6 +8,7 @@ import { Visraams } from '@hooks/useLocal';
  */
 export interface PathTextProps {
   gurbaniLine: string;
+  renderWordSegments?: string[] | null;
   onSelection: () => void;
   isSaving: boolean;
   pressIndex: number;
@@ -27,7 +28,6 @@ export interface PathTextProps {
   vishraams: Visraams;
   vishraamsSource?: string;
   vishraamsStyle?: string;
-  originalVerse?: string;
   onLayout?: (event: any) => void;
 }
 
@@ -69,6 +69,95 @@ export const useTextStyle = (fontSize: number) => {
     }),
     [fontSize]
   );
+};
+
+export type LarivaarRenderData = {
+  displayText: string;
+  wordSegments: string[] | null;
+};
+
+const ZERO_WIDTH_SPACE = '\u200B';
+
+const getGraphemes = (text: string): string[] => {
+  const { Segmenter } = Intl as { Segmenter?: any };
+  if (Segmenter) {
+    return Array.from(
+      new Segmenter(undefined, { granularity: 'grapheme' }).segment(text),
+      ({ segment }) => segment
+    );
+  }
+
+  return Array.from(text);
+};
+
+const buildGraphemeWrappedText = (text: string) => getGraphemes(text).join(ZERO_WIDTH_SPACE);
+
+const splitWords = (text?: string): string[] =>
+  text ? text.trim().split(/\s+/).filter(Boolean) : [];
+
+const buildAlignedLarivaarSegments = (
+  larivaar: string,
+  originalVerse?: string
+): string[] | null => {
+  const originalWords = splitWords(originalVerse);
+  if (originalWords.length <= 1) {
+    return null;
+  }
+
+  const originalWordLengths = originalWords.map((word) => getGraphemes(word).length);
+  const larivaarGraphemes = getGraphemes(larivaar);
+  if (larivaarGraphemes.length === 0) {
+    return null;
+  }
+
+  const segments: string[] = [];
+  let cursor = 0;
+
+  for (let index = 0; index < originalWordLengths.length; index += 1) {
+    const length = originalWordLengths[index];
+    if (length <= 0) {
+      return null;
+    }
+
+    const end = cursor + length;
+    if (end > larivaarGraphemes.length) {
+      return null;
+    }
+
+    const segment = larivaarGraphemes.slice(cursor, end).join('');
+    if (!segment) {
+      return null;
+    }
+
+    segments.push(segment);
+    cursor = end;
+  }
+
+  // Any remaining graphemes mean source and target are misaligned.
+  if (cursor !== larivaarGraphemes.length) {
+    return null;
+  }
+
+  return segments.length > 1 ? segments : null;
+};
+
+export const getLarivaarRenderData = (
+  larivaar: string,
+  originalVerse?: string
+): LarivaarRenderData => {
+  const wordSegments = buildAlignedLarivaarSegments(larivaar, originalVerse);
+
+  if (wordSegments && wordSegments.length > 1) {
+    return {
+      displayText: wordSegments.join(ZERO_WIDTH_SPACE),
+      wordSegments,
+    };
+  }
+
+  return {
+    displayText: buildGraphemeWrappedText(larivaar),
+    wordSegments: null,
+  };
 };
 
 /**
@@ -135,6 +224,7 @@ export const createPressHandler = (
 export const pathTextPropsAreEqual = (prevProps: PathTextProps, nextProps: PathTextProps) => {
   return (
     prevProps.gurbaniLine === nextProps.gurbaniLine &&
+    prevProps.renderWordSegments === nextProps.renderWordSegments &&
     prevProps.isSaving === nextProps.isSaving &&
     prevProps.pressIndex === nextProps.pressIndex &&
     prevProps.index === nextProps.index &&


### PR DESCRIPTION
# Problem
Larivaar + paragraph mode
  - With larivaar enabled, the displayed text has no visible spaces. That reduces natural wrap
    opportunities, so paragraph mode could stop reading like a flowing paragraph and instead wrap
    awkwardly.

Larivaar + Vishraams
  - Vishraams depend on word-level segmentation, but larivaar rendering and vishraam styling were not
    using one consistent segmentation path in paragraph mode.

Scroll resume and leaving the path
  - Saved scroll position could restore too early or from stale metadata, and leaving the Path screen
    could miss persisting the latest scroll state.
## Solution
Larivaar + paragraph mode
  - Paragraph mode now uses the actual larivaar text for both display and layout.
  - If the normal verse and larivaar text match after removing spaces, we reuse  those word boundaries and insert invisible separators so the text wraps like a paragraph.
  - If they do not match, we render larivaar as-is instead of forcing incorrect word splits.

  Larivaar + Vishraams

  - Vishraam styling uses the same larivaar word boundaries only when those boundaries are clearly valid.
  - This keeps paragraph rendering and vishraam styling consistent without guessing from mismatched text.
 
  Scroll resume and leaving the path

  - For scroll resume, we wait until content has real height before restoring the saved scroll position and apply restore after layout has settled.
  - We also persist the latest scroll position when leaving the Path screen, including drawer navigation, so reopen uses the latest saved state.